### PR TITLE
Implement VxWorks Queue

### DIFF
--- a/VxWorks/Os/CMakeLists.txt
+++ b/VxWorks/Os/CMakeLists.txt
@@ -18,5 +18,6 @@ register_fprime_module(Os_VxWorks_Shared)
 
 # Set up VxWorks implementation
 register_os_implementation("Console" VxWorks)
-register_os_implementation("Task" VxWorks Os_VxWorks_Shared Fw_Time)
 register_os_implementation("Mutex;ConditionVariable" VxWorks Os_VxWorks_Shared)
+register_os_implementation("Queue" VxWorks)
+register_os_implementation("Task" VxWorks Os_VxWorks_Shared Fw_Time)

--- a/VxWorks/Os/DefaultQueue.cpp
+++ b/VxWorks/Os/DefaultQueue.cpp
@@ -1,0 +1,13 @@
+// ======================================================================
+// \title VxWorks/Os/DefaultQueue.cpp
+// \brief sets default Os::Queue to VxWorks implementation via linker
+// ======================================================================
+#include "Os/Delegate.hpp"
+#include "Os/Queue.hpp"
+#include "VxWorks/Os/Queue.hpp"
+
+namespace Os {
+QueueInterface* QueueInterface::getDelegate(QueueHandleStorage& aligned_new_memory) {
+    return Os::Delegate::makeDelegate<QueueInterface, Os::VxWorks::Queue::VxWorksQueue>(aligned_new_memory);
+}
+}  // namespace Os

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -1,96 +1,44 @@
-#include <Os/Queue.hpp>
-
-#include <vxWorks.h>
-#include <msgQLib.h>
-
-#include <stdio.h>
-#include <string.h>
-#include <logLib.h>
+// ======================================================================
+// \title VxWorks/Os/Queue.cpp
+// \brief VxWorks implementation for Os::Queue
+// ======================================================================
+#include "Queue.hpp"
 
 namespace Os {
-    
-    Queue::Queue(): m_handle(0) {
-        
-    }
+namespace VxWorks {
+namespace Queue {
 
-    Queue::QueueStatus Queue::createInternal(const Fw::StringBase &name, NATIVE_INT_TYPE depth, NATIVE_INT_TYPE msgSize) {
-
-        this->m_name = "QV_";
-        this->m_name += name;
-
-        MSG_Q_ID handle = msgQCreate(depth,msgSize,MSG_Q_PRIORITY);
-        this->m_handle = handle == NULL?0:(POINTER_CAST)handle;
-        if (NULL == handle) {
-            return QUEUE_UNINITIALIZED;
-        }
-        Queue::s_numQueues++;
-        return QUEUE_OK;
-    }
-    
-    Queue::~Queue() {
-        (void)msgQDelete((MSG_Q_ID) this->m_handle);
-    }
-
-    Queue::QueueStatus Queue::send(const U8* buffer, NATIVE_INT_TYPE size, NATIVE_INT_TYPE priority, QueueBlocking block) {
-
-        if (0 == this->m_handle) {
-            return QUEUE_UNINITIALIZED;
-        }
-        
-        if (NULL == buffer) {
-            return QUEUE_EMPTY_BUFFER;
-        }
-        
-        NATIVE_INT_TYPE vxPrio = MSG_PRI_NORMAL;
-        if (priority > 0) {
-            vxPrio = MSG_PRI_URGENT;
-        }
-        
-        STATUS stat = msgQSend((MSG_Q_ID) this->m_handle, (char*) buffer, size, (QUEUE_NONBLOCKING == block)?NO_WAIT:WAIT_FOREVER, vxPrio);
-        
-        if (ERROR == stat) {
-            switch (errno) {
-                case S_msgQLib_INVALID_MSG_LENGTH:
-                    return QUEUE_SIZE_MISMATCH;
-                case S_objLib_OBJ_UNAVAILABLE:
-                case S_msgQLib_NON_ZERO_TIMEOUT_AT_INT_LEVEL:
-                    return QUEUE_FULL;
-                default:
-                    logMsg("Queue send error %s! %d\n",(int)strerror(errno),(int)this->m_handle,0,0,0,0);
-                    return QUEUE_UNKNOWN_ERROR;
-            }
-        } else {
-            return QUEUE_OK;
-        }
-    }
-
-    Queue::QueueStatus Queue::receive(U8* buffer, NATIVE_INT_TYPE capacity, NATIVE_INT_TYPE &actualSize, NATIVE_INT_TYPE &priority, QueueBlocking block) {
-        
-        if (0 == this->m_handle) {
-            return QUEUE_UNINITIALIZED;
-        }
-
-        actualSize = msgQReceive((MSG_Q_ID) this->m_handle, (char*)buffer, capacity, (QUEUE_NONBLOCKING == block)?NO_WAIT:WAIT_FOREVER);
-        
-        if (ERROR == actualSize) {
-            actualSize = 0;
-            switch (errno) {
-                case S_msgQLib_INVALID_MSG_LENGTH:
-                    return QUEUE_SIZE_MISMATCH;
-                case S_objLib_OBJ_UNAVAILABLE:
-                    return QUEUE_NO_MORE_MSGS;
-                default:
-                    logMsg("Queue receive error %s! %d %d\n",(int)strerror(errno),(int)this->m_handle,(int)block,0,0,0);
-                    return QUEUE_UNKNOWN_ERROR;
-            }
-        } else {
-            return QUEUE_OK;
-        }
-    }
-
-    NATIVE_INT_TYPE Queue::getNumMsgs(void) const {
-        return msgQNumMsgs((MSG_Q_ID) this->m_handle);
-    }
-
+QueueInterface::Status VxWorksQueue::create(const Fw::StringBase& name, FwSizeType depth, FwSizeType messageSize) {
+    return QueueInterface::Status::UNKNOWN_ERROR;
 }
 
+QueueInterface::Status VxWorksQueue::send(const U8* buffer,
+                                          FwSizeType size,
+                                          FwQueuePriorityType priority,
+                                          QueueInterface::BlockingType blockType) {
+    return QueueInterface::Status::UNINITIALIZED;
+}
+
+QueueInterface::Status VxWorksQueue::receive(U8* destination,
+                                             FwSizeType capacity,
+                                             QueueInterface::BlockingType blockType,
+                                             FwSizeType& actualSize,
+                                             FwQueuePriorityType& priority) {
+    return QueueInterface::Status::UNINITIALIZED;
+}
+
+FwSizeType VxWorksQueue::getMessagesAvailable() const {
+    return 0;
+}
+
+FwSizeType VxWorksQueue::getMessageHighWaterMark() const {
+    return 0;
+}
+
+QueueHandle* VxWorksQueue::getHandle() {
+    return &this->m_handle;
+}
+
+}  // namespace Queue
+}  // namespace VxWorks
+}  // namespace Os

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -3,20 +3,54 @@
 // \brief VxWorks implementation for Os::Queue
 // ======================================================================
 #include "Queue.hpp"
+#include <Fw/Types/Assert.hpp>
 
 namespace Os {
 namespace VxWorks {
 namespace Queue {
 
+VxWorksQueue::~VxWorksQueue() {
+    (void)msgQDelete(this->m_handle.m_queue);
+}
+
 QueueInterface::Status VxWorksQueue::create(const Fw::StringBase& name, FwSizeType depth, FwSizeType messageSize) {
     return QueueInterface::Status::UNKNOWN_ERROR;
+    this->m_handle.m_queue = msgQCreate(depth, messageSize, MSG_Q_PRIORITY);
+    if (this->m_handle.m_queue == MSG_Q_ID_NULL) {
+        return QueueInterface::Status::UNINITIALIZED;
+    }
+    return QueueInterface::Status::OP_OK;
 }
 
 QueueInterface::Status VxWorksQueue::send(const U8* buffer,
                                           FwSizeType size,
                                           FwQueuePriorityType priority,
                                           QueueInterface::BlockingType blockType) {
-    return QueueInterface::Status::UNINITIALIZED;
+    FW_ASSERT(buffer != nullptr);
+    if (this->m_handle.m_queue == MSG_Q_ID_NULL) {
+        return QueueInterface::Status::UNINITIALIZED;
+    }
+
+    PlatformIntType vxPrio = (priority > 0) ? MSG_PRI_URGENT : MSG_PRI_NORMAL;
+
+    // Doing a c-style cast here because msgQSend requires a char* and this is more
+    // efficient than copying from a const U8 buffer to a non-const char* buffer.
+    STATUS stat = msgQSend(this->m_handle.m_queue, (char*)buffer, size,
+                           (QueueInterface::BlockingType::NONBLOCKING == blockType) ? NO_WAIT : WAIT_FOREVER, vxPrio);
+
+    if (stat == VXWORKS_ERROR) {
+        switch (errno) {
+            case S_msgQLib_INVALID_MSG_LENGTH:
+                return QueueInterface::Status::SIZE_MISMATCH;
+            case S_objLib_OBJ_UNAVAILABLE:
+            case S_msgQLib_NON_ZERO_TIMEOUT_AT_INT_LEVEL:
+                return QueueInterface::Status::FULL;
+            default:
+                return QueueInterface::Status::UNKNOWN_ERROR;
+        }
+    }
+
+    return QueueInterface::Status::OP_OK;
 }
 
 QueueInterface::Status VxWorksQueue::receive(U8* destination,

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -14,7 +14,6 @@ VxWorksQueue::~VxWorksQueue() {
 }
 
 QueueInterface::Status VxWorksQueue::create(const Fw::StringBase& name, FwSizeType depth, FwSizeType messageSize) {
-    return QueueInterface::Status::UNKNOWN_ERROR;
     this->m_handle.m_queue = msgQCreate(depth, messageSize, MSG_Q_PRIORITY);
     if (this->m_handle.m_queue == MSG_Q_ID_NULL) {
         return QueueInterface::Status::UNINITIALIZED;
@@ -50,6 +49,11 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         }
     }
 
+    // Protect critical data m_highMark
+    {
+        Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
+        this->m_handle.m_highMark = FW_MAX(this->m_handle.m_highMark, this->getMessagesAvailable());
+    }
     return QueueInterface::Status::OP_OK;
 }
 
@@ -58,15 +62,38 @@ QueueInterface::Status VxWorksQueue::receive(U8* destination,
                                              QueueInterface::BlockingType blockType,
                                              FwSizeType& actualSize,
                                              FwQueuePriorityType& priority) {
-    return QueueInterface::Status::UNINITIALIZED;
+    FW_ASSERT(destination != nullptr);
+    if (this->m_handle.m_queue == MSG_Q_ID_NULL) {
+        return QueueInterface::Status::UNINITIALIZED;
+    }
+
+    // Casting destination to match API
+    actualSize = msgQReceive(this->m_handle.m_queue, reinterpret_cast<char*>(destination), capacity,
+                             (QueueInterface::BlockingType::NONBLOCKING == blockType) ? NO_WAIT : WAIT_FOREVER);
+
+    if (actualSize == VXWORKS_ERROR) {
+        actualSize = 0;
+        switch (errno) {
+            case S_msgQLib_INVALID_MSG_LENGTH:
+                return QueueInterface::Status::SIZE_MISMATCH;
+            case S_objLib_OBJ_UNAVAILABLE:
+                return QueueInterface::Status::EMPTY;
+            default:
+                return QueueInterface::Status::UNKNOWN_ERROR;
+        }
+    }
+    return QueueInterface::Status::OP_OK;
 }
 
 FwSizeType VxWorksQueue::getMessagesAvailable() const {
-    return 0;
+    FW_ASSERT(this->m_handle.m_queue != MSG_Q_ID_NULL);
+    return msgQNumMsgs(this->m_handle.m_queue);
 }
 
 FwSizeType VxWorksQueue::getMessageHighWaterMark() const {
-    return 0;
+    // Safe to cast away const in this context because scope lock will restore unlocked state on return
+    Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
+    return this->m_handle.m_highMark;
 }
 
 QueueHandle* VxWorksQueue::getHandle() {

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -1,0 +1,94 @@
+// ======================================================================
+// \title VxWorks/Os/Queue.hpp
+// \brief VxWorks definitions for Os::Queue
+// ======================================================================
+#ifndef OS_VXWORKS_QUEUE_HPP
+#define OS_VXWORKS_QUEUE_HPP
+#include "Os/Queue.hpp"
+
+namespace Os {
+namespace VxWorks {
+namespace Queue {
+
+struct VxWorksQueueHandle : public QueueHandle {};
+
+//! \brief VxWorks queue implementation with injectable statuses
+class VxWorksQueue : public QueueInterface {
+  public:
+    //! \brief default queue interface constructor
+    VxWorksQueue() = default;
+
+    //! \brief default queue destructor
+    virtual ~VxWorksQueue() = default;
+
+    //! \brief copy constructor is forbidden
+    VxWorksQueue(const QueueInterface& other) = delete;
+
+    //! \brief copy constructor is forbidden
+    VxWorksQueue(const QueueInterface* other) = delete;
+
+    //! \brief assignment operator is forbidden
+    VxWorksQueue& operator=(const QueueInterface& other) override = delete;
+
+    //! \brief create queue storage
+    //!
+    //! Creates a queue ensuring sufficient storage to hold `depth` messages of `messageSize` size each.
+    //! \param name: name of queue
+    //! \param depth: depth of queue in number of messages
+    //! \param messageSize: size of an individual message
+    //! \return: status of the creation
+    Status create(const Fw::StringBase& name, FwSizeType depth, FwSizeType messageSize) override;
+
+    //! \brief send a message into the queue
+    //!
+    //! Send a message into the queue, providing the message data, size, priority, and blocking type. When
+    //! `blockType` is set to BLOCKING, this call will block on queue full. Otherwise, this will return an error
+    //! status on queue full.
+    //!
+    //! \param buffer: message data
+    //! \param size: size of message data
+    //! \param priority: priority of the message
+    //! \param blockType: BLOCKING to block for space or NONBLOCKING to return error when queue is full
+    //! \return: status of the send
+    Status send(const U8* buffer, FwSizeType size, FwQueuePriorityType priority, BlockingType blockType) override;
+
+    //! \brief receive a message from the queue
+    //!
+    //! Receive a message from the queue, providing the message destination, capacity, priority, and blocking type.
+    //! When `blockType` is set to BLOCKING, this call will block on queue empty. Otherwise, this will return an
+    //! error status on queue empty. Actual size received and priority of message is set on success status.
+    //!
+    //! \param destination: destination for message data
+    //! \param capacity: maximum size of message data
+    //! \param blockType: BLOCKING to wait for message or NONBLOCKING to return error when queue is empty
+    //! \param actualSize: (output) actual size of message read
+    //! \param priority: (output) priority of message read
+    //! \return: status of the send
+    Status receive(U8* destination,
+                   FwSizeType capacity,
+                   BlockingType blockType,
+                   FwSizeType& actualSize,
+                   FwQueuePriorityType& priority) override;
+
+    //! \brief get number of messages available
+    //!
+    //! \return number of messages available
+    FwSizeType getMessagesAvailable() const override;
+
+    //! \brief get maximum messages stored at any given time
+    //!
+    //! Returns the maximum number of messages in this queue at any given time. This is the high-water mark for this
+    //! queue.
+    //! \return queue message high-water mark
+    FwSizeType getMessageHighWaterMark() const override;
+
+    QueueHandle* getHandle() override;
+
+    VxWorksQueueHandle m_handle;
+};
+
+}  // namespace Queue
+}  // namespace VxWorks
+}  // namespace Os
+
+#endif  // OS_VXWORKS_QUEUE_HPP

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -5,6 +5,7 @@
 #ifndef OS_VXWORKS_QUEUE_HPP
 #define OS_VXWORKS_QUEUE_HPP
 #include <msgQLib.h>
+#include "Os/Mutex.hpp"
 #include "Os/Queue.hpp"
 
 namespace Os {
@@ -13,6 +14,8 @@ namespace Queue {
 
 struct VxWorksQueueHandle : public QueueHandle {
     MSG_Q_ID m_queue = MSG_Q_ID_NULL;
+    Os::Mutex m_data_lock;      //!< Lock to proect updates on m_highMark
+    FwSizeType m_highMark = 0;  //!< Message count high water mark
 };
 
 //! \brief VxWorks queue implementation with injectable statuses

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -4,13 +4,16 @@
 // ======================================================================
 #ifndef OS_VXWORKS_QUEUE_HPP
 #define OS_VXWORKS_QUEUE_HPP
+#include <msgQLib.h>
 #include "Os/Queue.hpp"
 
 namespace Os {
 namespace VxWorks {
 namespace Queue {
 
-struct VxWorksQueueHandle : public QueueHandle {};
+struct VxWorksQueueHandle : public QueueHandle {
+    MSG_Q_ID m_queue = MSG_Q_ID_NULL;
+};
 
 //! \brief VxWorks queue implementation with injectable statuses
 class VxWorksQueue : public QueueInterface {
@@ -18,8 +21,8 @@ class VxWorksQueue : public QueueInterface {
     //! \brief default queue interface constructor
     VxWorksQueue() = default;
 
-    //! \brief default queue destructor
-    virtual ~VxWorksQueue() = default;
+    //! \brief queue destructor
+    ~VxWorksQueue() override;
 
     //! \brief copy constructor is forbidden
     VxWorksQueue(const QueueInterface& other) = delete;

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -14,7 +14,7 @@ namespace Queue {
 
 struct VxWorksQueueHandle : public QueueHandle {
     MSG_Q_ID m_queue = MSG_Q_ID_NULL;
-    Os::Mutex m_data_lock;      //!< Lock to proect updates on m_highMark
+    Os::Mutex m_data_lock;      //!< Lock to protect m_highMark
     FwSizeType m_highMark = 0;  //!< Message count high water mark
 };
 

--- a/cmake/platform/VxWorks.cmake
+++ b/cmake/platform/VxWorks.cmake
@@ -10,7 +10,7 @@ choose_fprime_implementation(Os/Cpu Os/Cpu/Stub)
 choose_fprime_implementation(Os/File Os/File/Stub)
 choose_fprime_implementation(Os/Memory Os/Memory/Stub)
 choose_fprime_implementation(Os/Mutex Os/Mutex/VxWorks)
-choose_fprime_implementation(Os/Queue Os/Generic/PriorityQueue)
+choose_fprime_implementation(Os/Queue Os/Queue/VxWorks)
 choose_fprime_implementation(Os/RawTime Os/RawTime/Stub)
 choose_fprime_implementation(Os/Task Os/Task/VxWorks)
 


### PR DESCRIPTION
This implements the last missing piece for a full VxWorks OSAL -- the Queue. I was able to build and run my fprime-vxworks-reference deployment on my BBB and it worked as expected. A TODO for a future release is to add unit testing for this layer similar to UTs in fprime's OS directory.