### PR TITLE
Added define to enable/disable high watermark

### DIFF
--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -49,11 +49,13 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         }
     }
 
+#ifdef ENABLE_HIGH_WATERMARK
     // Protect critical data m_highMark
     {
         Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
         this->m_handle.m_highMark = FW_MAX(this->m_handle.m_highMark, this->getMessagesAvailable());
     }
+#endif
     return QueueInterface::Status::OP_OK;
 }
 
@@ -91,9 +93,13 @@ FwSizeType VxWorksQueue::getMessagesAvailable() const {
 }
 
 FwSizeType VxWorksQueue::getMessageHighWaterMark() const {
+#ifdef ENABLE_HIGH_WATERMARK
     // Safe to cast away const in this context because scope lock will restore unlocked state on return
     Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
     return this->m_handle.m_highMark;
+#else
+    return 0;
+#endif
 }
 
 QueueHandle* VxWorksQueue::getHandle() {

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -49,7 +49,7 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         }
     }
 
-#ifdef ENABLE_HIGH_WATERMARK
+#if ENABLE_HIGH_WATERMARK
     // Protect critical data m_highMark
     {
         Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
@@ -93,7 +93,7 @@ FwSizeType VxWorksQueue::getMessagesAvailable() const {
 }
 
 FwSizeType VxWorksQueue::getMessageHighWaterMark() const {
-#ifdef ENABLE_HIGH_WATERMARK
+#if ENABLE_HIGH_WATERMARK
     // Safe to cast away const in this context because scope lock will restore unlocked state on return
     Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
     return this->m_handle.m_highMark;

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -49,7 +49,7 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         }
     }
 
-#if ENABLE_HIGH_WATERMARK
+#ifdef ENABLE_HIGH_WATERMARK
     // Protect critical data m_highMark
     {
         Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
@@ -93,7 +93,7 @@ FwSizeType VxWorksQueue::getMessagesAvailable() const {
 }
 
 FwSizeType VxWorksQueue::getMessageHighWaterMark() const {
-#if ENABLE_HIGH_WATERMARK
+#ifdef ENABLE_HIGH_WATERMARK
     // Safe to cast away const in this context because scope lock will restore unlocked state on return
     Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
     return this->m_handle.m_highMark;

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -3,6 +3,7 @@
 // \brief VxWorks implementation for Os::Queue
 // ======================================================================
 #include "Queue.hpp"
+#include <limits.h>
 #include <Fw/Types/Assert.hpp>
 
 namespace Os {
@@ -48,14 +49,6 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
                 return QueueInterface::Status::UNKNOWN_ERROR;
         }
     }
-
-#ifdef ENABLE_HIGH_WATERMARK
-    // Protect critical data m_highMark
-    {
-        Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
-        this->m_handle.m_highMark = FW_MAX(this->m_handle.m_highMark, this->getMessagesAvailable());
-    }
-#endif
     return QueueInterface::Status::OP_OK;
 }
 
@@ -93,13 +86,7 @@ FwSizeType VxWorksQueue::getMessagesAvailable() const {
 }
 
 FwSizeType VxWorksQueue::getMessageHighWaterMark() const {
-#ifdef ENABLE_HIGH_WATERMARK
-    // Safe to cast away const in this context because scope lock will restore unlocked state on return
-    Os::ScopeLock lock(const_cast<Mutex&>(this->m_handle.m_data_lock));
-    return this->m_handle.m_highMark;
-#else
-    return 0;
-#endif
+    return std::numeric_limits<FwSizeType>::max();
 }
 
 QueueHandle* VxWorksQueue::getHandle() {


### PR DESCRIPTION
This is a quick fix for https://github.com/nasa/fprime/issues/3201, where you can:

```
fprime-util generate -DENABLE_HIGH_WATERMARK=ON
```

to use this feature if desired.