### PR TITLE
Implementing Os::Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# Set up
+# Project Setup
+
+## settings.ini
 Make sure to add the following to your project's `settings.ini` file:
 
 1. Add the path to `fprime-vxworks` to `library_locations`
-2. Add to `default_cmake_options` the following where `FPRIME_PLATFORM` is assigned to your selected platform (`VxWorks-Posix` in this case)
+2. Add to `default_cmake_options` the following where `FPRIME_PLATFORM` is assigned to your selected platform (`VxWorks` in this case)
    ```cmake
    VX_TARGET_TYPE=DKM
-   FPRIME_PLATFORM=VxWorks-Posix
+   FPRIME_PLATFORM=VxWorks
    ```
 3. Define `WIND_CC_SYSROOT` in the `environment` section. This variable should point to your project's VxWorks Source Build (VSB).
 
 > NOTE: `VX_TARGET_TYPE`, `FPRIME_PLATFORM`, and `WIND_CC_SYSROOT` are required definitions by this VxWorks toolchain. 
 
-# Example settings.ini
+### Example settings.ini
 This is an example for a project's `settings.ini` file that uses fprime-vxworks for POSIX. 
 ```
 [fprime]
@@ -24,8 +26,10 @@ default_toolchain: vxworks
 default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
                         FPRIME_ENABLE_AUTOCODER_UTS=OFF
                         VX_TARGET_TYPE=DKM
-                        FPRIME_PLATFORM=VxWorks-Posix
+                        FPRIME_PLATFORM=VxWorks
 
 [environment]
 WIND_CC_SYSROOT: $HOME/projects/vxworks/vxworks-7-bsp-generator/bsp/VxWorks7-22.09-BeagleBoneBlack-Source
 ```
+## Configuration
+Copy the configuration file [`config/VxWorksCfg.hpp`](config/VxWorksCfg.hpp) to your project's configuration directory.

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -19,7 +19,7 @@ void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
         const FwSizeType currentIndex = this->m_handle.m_tail_index.fetch_add(1) % MAX_CONSOLE_CAPACITY;
         FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),
                   static_cast<FwAssertArgType>(MAX_CONSOLE_CAPACITY));
-        FwSizeType minSize = FW_MIN(size, MAX_CONSOLE_MESSAGE_BYTE_SIZE);
+        FwSizeType minSize = FW_MIN(size, MAX_CONSOLE_MESSAGE_BYTE_SIZE - 1);
         (void)memcpy(this->m_handle.circularBuffer[currentIndex], message, minSize);
         this->m_handle.circularBuffer[currentIndex][minSize] = '\0';
         (void)logMsg(this->m_handle.circularBuffer[currentIndex], 0, 0, 0, 0, 0, 0);

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -15,6 +15,7 @@ void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
         static_assert(std::is_unsigned<FwSizeType>::value, "FwSizeType is expected to be unsigned.");
         static_assert(MAX_CONSOLE_CAPACITY > 0, "Avoid dividing by zero.");
+        static_assert(MAX_CONSOLE_MESSAGE_BYTE_SIZE > 0, "Should not have a message size of 0 bytes."
         // Rely on unsigned overflow to atomically roll over tail index
         const FwSizeType currentIndex = this->m_handle.m_tail_index.fetch_add(1) % MAX_CONSOLE_CAPACITY;
         FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -15,7 +15,7 @@ void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
         static_assert(std::is_unsigned<FwSizeType>::value, "FwSizeType is expected to be unsigned.");
         static_assert(MAX_CONSOLE_CAPACITY > 0, "Avoid dividing by zero.");
-        static_assert(MAX_CONSOLE_MESSAGE_BYTE_SIZE > 0, "Should not have a message size of 0 bytes."
+        static_assert(MAX_CONSOLE_MESSAGE_BYTE_SIZE > 0, "Should not have a message size of 0 bytes.");
         // Rely on unsigned overflow to atomically roll over tail index
         const FwSizeType currentIndex = this->m_handle.m_tail_index.fetch_add(1) % MAX_CONSOLE_CAPACITY;
         FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -14,7 +14,7 @@ namespace Console {
 void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
         static_assert(std::is_unsigned<FwSizeType>::value, "FwSizeType is expected to be unsigned.");
-        static_assert(MAX_CONSOLE_CAPACITY > 0);
+        static_assert(MAX_CONSOLE_CAPACITY > 0, "Avoid dividing by zero.");
         // Rely on unsigned overflow to atomically roll over tail index
         const FwSizeType currentIndex = this->m_handle.m_tail_index.fetch_add(1) % MAX_CONSOLE_CAPACITY;
         FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),
@@ -22,7 +22,7 @@ void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
         FwSizeType minSize = FW_MIN(size, MAX_CONSOLE_MESSAGE_BYTE_SIZE);
         (void)memcpy(this->m_handle.circularBuffer[currentIndex], message, minSize);
         this->m_handle.circularBuffer[currentIndex][minSize] = '\0';
-        logMsg(this->m_handle.circularBuffer[currentIndex], 0, 0, 0, 0, 0, 0);
+        (void)logMsg(this->m_handle.circularBuffer[currentIndex], 0, 0, 0, 0, 0, 0);
     }
 }
 

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -3,43 +3,29 @@
 // \brief VxWorks implementation for Os::Console
 // ======================================================================
 #include "Console.hpp"
+#include <logLib.h>
 #include <Fw/Types/Assert.hpp>
-#include <cstdio>
-#include <limits>
+#include <cstring>
 
 namespace Os {
 namespace VxWorks {
 namespace Console {
 
 void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
-    // size_t is defined as different sizes on different platforms. Since FwSizeType is likely larger than size_t
-    // on these platforms, and the user is unlikely to console-log more than size_t-max data, we cap the total
-    // size at the limit of the interface.
-    FwSizeType capped_size = (size < std::numeric_limits<size_t>::max())
-                                 ? size
-                                 : static_cast<FwSizeType>(std::numeric_limits<size_t>::max());
     if (message != nullptr) {
-        (void)::fwrite(message, sizeof(CHAR), static_cast<size_t>(capped_size), this->m_handle.m_file_descriptor);
-        (void)::fflush(this->m_handle.m_file_descriptor);
+        FwIndexType m_tail_index = this->m_handle.m_tail_index;
+        FW_ASSERT(m_tail_index < CONSOLE_CAPACITY, m_tail_index, CONSOLE_CAPACITY);
+        FwSizeType minSize = FW_MIN(size, CONSOLE_MESSAGE_SIZE);
+        (void)memcpy(this->m_handle.circularBuffer[m_tail_index], message, minSize);
+        this->m_handle.circularBuffer[m_tail_index][minSize] = '\0';
+        logMsg(this->m_handle.circularBuffer[m_tail_index], 0, 0, 0, 0, 0, 0);
+        m_tail_index = ((m_tail_index + 1) % CONSOLE_CAPACITY);
+        this->m_handle.m_tail_index = m_tail_index;
     }
 }
 
 ConsoleHandle* VxWorksConsole::getHandle() {
     return &this->m_handle;
-}
-
-void VxWorksConsole ::setOutputStream(Stream stream) {
-    switch (stream) {
-        case STANDARD_OUT:
-            this->m_handle.m_file_descriptor = stdout;
-            break;
-        case STANDARD_ERROR:
-            this->m_handle.m_file_descriptor = stderr;
-            break;
-        default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(stream));
-            break;
-    }
 }
 
 }  // namespace Console

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -13,14 +13,14 @@ namespace Console {
 
 void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
-        FwIndexType m_tail_index = this->m_handle.m_tail_index;
-        FW_ASSERT(m_tail_index < MAX_CONSOLE_CAPACITY, m_tail_index, MAX_CONSOLE_CAPACITY);
+        FwSizeType currentIndex = this->m_handle.m_tail_index;
+        FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),
+                  static_cast<FwAssertArgType>(MAX_CONSOLE_CAPACITY));
         FwSizeType minSize = FW_MIN(size, MAX_CONSOLE_MESSAGE_BYTE_SIZE);
-        (void)memcpy(this->m_handle.circularBuffer[m_tail_index], message, minSize);
-        this->m_handle.circularBuffer[m_tail_index][minSize] = '\0';
-        logMsg(this->m_handle.circularBuffer[m_tail_index], 0, 0, 0, 0, 0, 0);
-        m_tail_index = ((m_tail_index + 1) % MAX_CONSOLE_CAPACITY);
-        this->m_handle.m_tail_index = m_tail_index;
+        (void)memcpy(this->m_handle.circularBuffer[currentIndex], message, minSize);
+        this->m_handle.circularBuffer[currentIndex][minSize] = '\0';
+        logMsg(this->m_handle.circularBuffer[currentIndex], 0, 0, 0, 0, 0, 0);
+        this->m_handle.m_tail_index = ((currentIndex + 1) % MAX_CONSOLE_CAPACITY);
     }
 }
 

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -14,6 +14,7 @@ namespace Console {
 void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
         static_assert(std::is_unsigned<FwSizeType>::value, "FwSizeType is expected to be unsigned.");
+        static_assert(MAX_CONSOLE_CAPACITY > 0);
         // Rely on unsigned overflow to atomically roll over tail index
         const FwSizeType currentIndex = this->m_handle.m_tail_index.fetch_add(1) % MAX_CONSOLE_CAPACITY;
         FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -14,12 +14,12 @@ namespace Console {
 void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
         FwIndexType m_tail_index = this->m_handle.m_tail_index;
-        FW_ASSERT(m_tail_index < CONSOLE_CAPACITY, m_tail_index, CONSOLE_CAPACITY);
-        FwSizeType minSize = FW_MIN(size, CONSOLE_MESSAGE_SIZE);
+        FW_ASSERT(m_tail_index < MAX_CONSOLE_CAPACITY, m_tail_index, MAX_CONSOLE_CAPACITY);
+        FwSizeType minSize = FW_MIN(size, MAX_CONSOLE_MESSAGE_BYTE_SIZE);
         (void)memcpy(this->m_handle.circularBuffer[m_tail_index], message, minSize);
         this->m_handle.circularBuffer[m_tail_index][minSize] = '\0';
         logMsg(this->m_handle.circularBuffer[m_tail_index], 0, 0, 0, 0, 0, 0);
-        m_tail_index = ((m_tail_index + 1) % CONSOLE_CAPACITY);
+        m_tail_index = ((m_tail_index + 1) % MAX_CONSOLE_CAPACITY);
         this->m_handle.m_tail_index = m_tail_index;
     }
 }

--- a/VxWorks/Os/Console.cpp
+++ b/VxWorks/Os/Console.cpp
@@ -13,14 +13,15 @@ namespace Console {
 
 void VxWorksConsole::writeMessage(const CHAR* message, const FwSizeType size) {
     if (message != nullptr) {
-        FwSizeType currentIndex = this->m_handle.m_tail_index;
+        static_assert(std::is_unsigned<FwSizeType>::value, "FwSizeType is expected to be unsigned.");
+        // Rely on unsigned overflow to atomically roll over tail index
+        const FwSizeType currentIndex = this->m_handle.m_tail_index.fetch_add(1) % MAX_CONSOLE_CAPACITY;
         FW_ASSERT(currentIndex < MAX_CONSOLE_CAPACITY, static_cast<FwAssertArgType>(currentIndex),
                   static_cast<FwAssertArgType>(MAX_CONSOLE_CAPACITY));
         FwSizeType minSize = FW_MIN(size, MAX_CONSOLE_MESSAGE_BYTE_SIZE);
         (void)memcpy(this->m_handle.circularBuffer[currentIndex], message, minSize);
         this->m_handle.circularBuffer[currentIndex][minSize] = '\0';
         logMsg(this->m_handle.circularBuffer[currentIndex], 0, 0, 0, 0, 0, 0);
-        this->m_handle.m_tail_index = ((currentIndex + 1) % MAX_CONSOLE_CAPACITY);
     }
 }
 

--- a/VxWorks/Os/Console.hpp
+++ b/VxWorks/Os/Console.hpp
@@ -7,6 +7,8 @@
 #ifndef OS_VXWORKS_Console_HPP
 #define OS_VXWORKS_Console_HPP
 
+#include <atomic>
+
 namespace Os {
 namespace VxWorks {
 namespace Console {
@@ -15,7 +17,21 @@ namespace Console {
 //!
 struct VxWorksConsoleHandle : public ConsoleHandle {
     char circularBuffer[MAX_CONSOLE_CAPACITY][MAX_CONSOLE_MESSAGE_BYTE_SIZE];  // Circular buffer to store messages
-    FwIndexType m_tail_index = 0;  // Index pointing to the tail of the circular buffer
+    std::atomic<FwSizeType> m_tail_index;  // Index pointing to the tail of the circular buffer
+
+    VxWorksConsoleHandle() = default;
+
+    VxWorksConsoleHandle(const VxWorksConsoleHandle& other) {
+        if (&other == this) {
+            return;
+        }
+        m_tail_index = 0;
+    }
+
+    VxWorksConsoleHandle& operator=(const VxWorksConsoleHandle& other) {
+        this->m_tail_index = 0;
+        return *this;
+    }
 };
 
 //! \brief VxWorks implementation of Os::ConsoleInterface

--- a/VxWorks/Os/Console.hpp
+++ b/VxWorks/Os/Console.hpp
@@ -14,8 +14,8 @@ namespace Console {
 //! ConsoleHandle class definition for VxWorks implementations.
 //!
 struct VxWorksConsoleHandle : public ConsoleHandle {
-    char circularBuffer[CONSOLE_CAPACITY][CONSOLE_MESSAGE_SIZE];  // Circular buffer to store messages
-    FwIndexType m_tail_index = 0;                                 // Index pointing to the tail of the circular buffer
+    char circularBuffer[MAX_CONSOLE_CAPACITY][MAX_CONSOLE_MESSAGE_BYTE_SIZE];  // Circular buffer to store messages
+    FwIndexType m_tail_index = 0;  // Index pointing to the tail of the circular buffer
 };
 
 //! \brief VxWorks implementation of Os::ConsoleInterface

--- a/VxWorks/Os/Console.hpp
+++ b/VxWorks/Os/Console.hpp
@@ -3,7 +3,7 @@
 // \brief VxWorks implementation for Os::Console, header and test definitions
 // ======================================================================
 #include <Os/Console.hpp>
-#include <cstdio>
+#include <VxWorksCfg.hpp>
 #ifndef OS_VXWORKS_Console_HPP
 #define OS_VXWORKS_Console_HPP
 
@@ -14,8 +14,8 @@ namespace Console {
 //! ConsoleHandle class definition for VxWorks implementations.
 //!
 struct VxWorksConsoleHandle : public ConsoleHandle {
-    //! VxWorks console file descriptor
-    FILE* m_file_descriptor = stdout;
+    char circularBuffer[CONSOLE_CAPACITY][CONSOLE_MESSAGE_SIZE];  // Circular buffer to store messages
+    FwIndexType m_tail_index = 0;                                 // Index pointing to the tail of the circular buffer
 };
 
 //! \brief VxWorks implementation of Os::ConsoleInterface
@@ -26,11 +26,6 @@ struct VxWorksConsoleHandle : public ConsoleHandle {
 //!
 class VxWorksConsole : public ConsoleInterface {
   public:
-    //! Stream selection enumeration
-    enum Stream {
-        STANDARD_OUT = 0,   //!< Use standard output stream
-        STANDARD_ERROR = 1  //!< Use standard error stream
-    };
     //! \brief constructor
     //!
     VxWorksConsole() = default;
@@ -67,11 +62,9 @@ class VxWorksConsole : public ConsoleInterface {
     //!
     ConsoleHandle* getHandle() override;
 
-    //! \brief select the output stream
-    //!
-    //! There are two streams defined: standard out, and standard error. This allows users of the VxWorks log
-    //! implementation to chose which stream to use.
-    void setOutputStream(Stream stream);
+    // ------------------------------------
+    // Helper functions
+    // ------------------------------------
 
   private:
     //! File handle for VxWorksFile

--- a/VxWorks/Os/Console.hpp
+++ b/VxWorks/Os/Console.hpp
@@ -62,10 +62,6 @@ class VxWorksConsole : public ConsoleInterface {
     //!
     ConsoleHandle* getHandle() override;
 
-    // ------------------------------------
-    // Helper functions
-    // ------------------------------------
-
   private:
     //! File handle for VxWorksFile
     VxWorksConsoleHandle m_handle;

--- a/VxWorks/Os/Console.hpp
+++ b/VxWorks/Os/Console.hpp
@@ -19,7 +19,7 @@ struct VxWorksConsoleHandle : public ConsoleHandle {
     char circularBuffer[MAX_CONSOLE_CAPACITY][MAX_CONSOLE_MESSAGE_BYTE_SIZE];  // Circular buffer to store messages
     std::atomic<FwSizeType> m_tail_index;  // Index pointing to the tail of the circular buffer
 
-    VxWorksConsoleHandle() = default;
+    VxWorksConsoleHandle() { m_tail_index = 0; }
 
     VxWorksConsoleHandle(const VxWorksConsoleHandle& other) {
         if (&other == this) {

--- a/config/VxWorksCfg.hpp
+++ b/config/VxWorksCfg.hpp
@@ -11,8 +11,8 @@
 namespace Os {
 namespace VxWorks {
 
-static constexpr PlatformSizeType CONSOLE_CAPACITY = 10;       // Max number of messages that can be stored
-static constexpr PlatformSizeType CONSOLE_MESSAGE_SIZE = 256;  // Max message size
+static constexpr PlatformSizeType MAX_CONSOLE_CAPACITY = 10;       // Max number of messages that can be stored
+static constexpr PlatformSizeType MAX_CONSOLE_MESSAGE_BYTE_SIZE = 256;  // Max message size
 
 }  // namespace VxWorks
 }  // namespace Os

--- a/config/VxWorksCfg.hpp
+++ b/config/VxWorksCfg.hpp
@@ -11,8 +11,8 @@
 namespace Os {
 namespace VxWorks {
 
-static constexpr PlatformSizeType MAX_CONSOLE_CAPACITY = 10;       // Max number of messages that can be stored
-static constexpr PlatformSizeType MAX_CONSOLE_MESSAGE_BYTE_SIZE = 256;  // Max message size
+static constexpr PlatformSizeType MAX_CONSOLE_CAPACITY = 30;            // Max number of messages that can be stored
+static constexpr PlatformSizeType MAX_CONSOLE_MESSAGE_BYTE_SIZE = 128;  // Max message size
 
 }  // namespace VxWorks
 }  // namespace Os

--- a/config/VxWorksCfg.hpp
+++ b/config/VxWorksCfg.hpp
@@ -1,0 +1,20 @@
+/*
+ * VxWorksCfg.hpp:
+ *
+ * Configuration settings for VxWorks.
+ */
+
+#ifndef VXWORKS_OS_CONFIG_HPP_
+#define VXWORKS_OS_CONFIG_HPP_
+#include <Fw/Types/BasicTypes.hpp>
+
+namespace Os {
+namespace VxWorks {
+
+static constexpr PlatformSizeType CONSOLE_CAPACITY = 10;       // Max number of messages that can be stored
+static constexpr PlatformSizeType CONSOLE_MESSAGE_SIZE = 256;  // Max message size
+
+}  // namespace VxWorks
+}  // namespace Os
+
+#endif /* VXWORKS_OS_CONFIG_HPP_ */


### PR DESCRIPTION
Replace the use of `fwrite` with Vxworks' `logMsg` since logMsg is better to use in interrupt context. One caveat with `logMsg` is its inability to handle a lot of messages. This causes log messages to get jumbled up. I added a circular buffer to assist (but not fully alleviate) the problem. There is still an issue where competing threads or processors can access the circular buffer and trample over each other. But per discussion with the F Prime team, that has been deemed low risk.

With this PR, users will now need to copy over `config/VxWorksCfg.hpp` to their project's configuration directory. With this new config file, users can tune how large each log message can be or how many messages can be stored in the circular buffer. Making changes to these config values may require users to update `FW_CONSOLE_HANDLE_MAX_SIZE` inside of FpConfig.h.