### PR TITLE
Add checks to Os::Queue::send

### DIFF
--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -31,6 +31,16 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         return QueueInterface::Status::UNINITIALIZED;
     }
 
+    // VxWorks queues do not support true priority.  Priority of 1 or 0 is only allowed in cases where an ISR needs to
+    // be shuttled to the front of the line. This is because prioritized messages in VxWorks are in LIFO order and only
+    // support a boolean priority, which violates key expectations of Os::Queue. This is allowed in interrupt context as
+    // interrupts typically need to be processed with high priority.
+    if (!((intContext() && priority < 2) || priority == 0)) {
+        return QueueInterface::Status::NOT_SUPPORTED;
+    }
+
+    // Should not block in interrupt context.
+    FW_ASSERT(!(intContext() && blockType == QueueInterface::BlockingType::BLOCKING));
     PlatformIntType vxPrio = (priority > 0) ? MSG_PRI_URGENT : MSG_PRI_NORMAL;
 
     // Casting buffer to match API

--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -31,7 +31,10 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         return QueueInterface::Status::UNINITIALIZED;
     }
 
-    // VxWorks queues do not support true priority.  Priority of 1 or 0 is only allowed in cases where an ISR needs to
+    // It is illegal to block while in interrupt context
+    FW_ASSERT(!(intContext() && blockType == QueueInterface::BlockingType::BLOCKING));
+
+    // VxWorks queues do not support true priority.  Priority of 1 is only allowed in cases where an ISR needs to
     // be shuttled to the front of the line. This is because prioritized messages in VxWorks are in LIFO order and only
     // support a boolean priority, which violates key expectations of Os::Queue. This is allowed in interrupt context as
     // interrupts typically need to be processed with high priority.
@@ -39,8 +42,6 @@ QueueInterface::Status VxWorksQueue::send(const U8* buffer,
         return QueueInterface::Status::NOT_SUPPORTED;
     }
 
-    // Should not block in interrupt context.
-    FW_ASSERT(!(intContext() && blockType == QueueInterface::BlockingType::BLOCKING));
     PlatformIntType vxPrio = (priority > 0) ? MSG_PRI_URGENT : MSG_PRI_NORMAL;
 
     // Casting buffer to match API

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -21,6 +21,7 @@ struct VxWorksQueueHandle : public QueueHandle {
 //! \note This queue implementation does not implement high watermark.
 //! \note This queue implementation is not a true priority queue. Any message with a priority of 1 will be
 //! added to the head of the list and any message with a priority of 0 will be added to the tail of the list.
+//! \note Messages with a priority of 1 is only supported in ISR context.
 class VxWorksQueue : public QueueInterface {
   public:
     //! \brief default queue interface constructor

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -21,7 +21,7 @@ struct VxWorksQueueHandle : public QueueHandle {
 //! \note This queue implementation does not implement high watermark.
 //! \note This queue implementation is not a true priority queue. Any message with a priority of 1 will be
 //! added to the head of the list and any message with a priority of 0 will be added to the tail of the list.
-//! \note Messages with a priority of 1 is only supported in ISR context.
+//! \note Messages with a priority of 1 are only supported in ISR context.
 class VxWorksQueue : public QueueInterface {
   public:
     //! \brief default queue interface constructor

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -19,8 +19,8 @@ struct VxWorksQueueHandle : public QueueHandle {
 //! \brief VxWorks queue implementation with injectable statuses
 //!
 //! \note This queue implementation does not implement high watermark.
-//! \note This queue implementation is not a true priority queue. Any message with a priority greater than 0 will be
-//! added to the head of the list regardless of the priority of the message at the head of the queue.
+//! \note This queue implementation is not a true priority queue. Any message with a priority of 1 will be
+//! added to the head of the list and any message with a priority of 0 will be added to the tail of the list.
 class VxWorksQueue : public QueueInterface {
   public:
     //! \brief default queue interface constructor
@@ -55,8 +55,8 @@ class VxWorksQueue : public QueueInterface {
     //!
     //! \param buffer: message data
     //! \param size: size of message data
-    //! \param priority: priority of the message. Any message with priority greater than 0 will be added to the head of
-    //! the queue.
+    //! \param priority: priority of the message. Only messages with a priority of 1 or 0 are allowed in ISR context,
+    //!                  otherwise only 0 priority is allowed.
     //! \param blockType: BLOCKING to block for space or NONBLOCKING to return error when queue is full
     //! \return: status of the send
     Status send(const U8* buffer, FwSizeType size, FwQueuePriorityType priority, BlockingType blockType) override;


### PR DESCRIPTION
Adding checks on input arguments to Os::Queue:send.

Still need to update fprime to include `NOT_SUPPORTED` status to OSAL