### PR TITLE
Handling default task values

### DIFF
--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -43,15 +43,14 @@ Os::Task::Status VxWorksTask::start(const Arguments& arguments) {
         return Os::Task::Status::INVALID_STACK;
     }
 
-    int priority = static_cast<int>(arguments.m_priority);
     if (arguments.m_priority == Os::Task::TASK_PRIORITY_DEFAULT) {
-        priority = 255;  // lowest priority
+        return Os::Task::Status::INVALID_PARAMS;
     }
 
-    this->m_handle.m_task_descriptor =
-        taskCreate(taskName, priority, VX_FP_TASK, static_cast<size_t>(arguments.m_stackSize),
-                   reinterpret_cast<FUNCPTR>(myRoutineWrapper), reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine),
-                   reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine_argument), 0, 0, 0, 0, 0, 0, 0, 0);
+    this->m_handle.m_task_descriptor = taskCreate(
+        taskName, static_cast<int>(arguments.m_priority), VX_FP_TASK, static_cast<size_t>(arguments.m_stackSize),
+        reinterpret_cast<FUNCPTR>(myRoutineWrapper), reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine),
+        reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine_argument), 0, 0, 0, 0, 0, 0, 0, 0);
 
     if (this->m_handle.m_task_descriptor == TASK_ID_NULL) {
         return Os::Task::Status::UNKNOWN_ERROR;

--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -43,7 +43,7 @@ Os::Task::Status VxWorksTask::start(const Arguments& arguments) {
         return Os::Task::Status::INVALID_STACK;
     }
 
-    int priority = arguments.m_priority;
+    int priority = static_cast<int>(arguments.m_priority);
     if (arguments.m_priority == Os::Task::TASK_PRIORITY_DEFAULT) {
         priority = 255;  // lowest priority
     }

--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -39,6 +39,8 @@ Os::Task::Status VxWorksTask::start(const Arguments& arguments) {
     auto minimumStringSize = FW_MIN(sizeof(taskName), arguments.m_name.getCapacity());
     memcpy(taskName, arguments.m_name.toChar(), minimumStringSize);
 
+    FW_ASSERT(arguments.m_stackSize != Os::Task::TASK_DEFAULT, static_cast<FwAssertArgType>(arguments.m_stackSize));
+
     this->m_handle.m_task_descriptor = taskCreate(
         taskName, static_cast<int>(arguments.m_priority), VX_FP_TASK, static_cast<size_t>(arguments.m_stackSize),
         reinterpret_cast<FUNCPTR>(myRoutineWrapper), reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine),

--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -39,7 +39,9 @@ Os::Task::Status VxWorksTask::start(const Arguments& arguments) {
     auto minimumStringSize = FW_MIN(sizeof(taskName), arguments.m_name.getCapacity());
     memcpy(taskName, arguments.m_name.toChar(), minimumStringSize);
 
-    FW_ASSERT(arguments.m_stackSize != Os::Task::TASK_DEFAULT, static_cast<FwAssertArgType>(arguments.m_stackSize));
+    if (arguments.m_stackSize == Os::Task::TASK_DEFAULT) {
+        return Os::Task::Status::INVALID_STACK;
+    }
 
     this->m_handle.m_task_descriptor = taskCreate(
         taskName, static_cast<int>(arguments.m_priority), VX_FP_TASK, static_cast<size_t>(arguments.m_stackSize),

--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -44,7 +44,7 @@ Os::Task::Status VxWorksTask::start(const Arguments& arguments) {
     }
 
     if (arguments.m_priority == Os::Task::TASK_PRIORITY_DEFAULT) {
-        return Os::Task::Status::INVALID_PARAMS;
+        return Os::Task::Status::INVALID_PRIORITY;
     }
 
     this->m_handle.m_task_descriptor = taskCreate(

--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -21,9 +21,8 @@ namespace Task {
 //!< FUNCPTR signature required by VxWorks7 and calls the routine
 //!< with the provides arg. This wrapper function is expected to be
 //!< passed in to taskCreate.
-static int myRoutineWrapper(
-    Os::TaskInterface::taskRoutine routine,  //!< Routine that should run in a thread
-    void* arg                                //!< Argument passed to the routine
+static int myRoutineWrapper(Os::TaskInterface::taskRoutine routine,  //!< Routine that should run in a thread
+                            void* arg                                //!< Argument passed to the routine
 ) {
     routine(arg);
     return OK;

--- a/VxWorks/Os/Task.cpp
+++ b/VxWorks/Os/Task.cpp
@@ -43,16 +43,22 @@ Os::Task::Status VxWorksTask::start(const Arguments& arguments) {
         return Os::Task::Status::INVALID_STACK;
     }
 
-    this->m_handle.m_task_descriptor = taskCreate(
-        taskName, static_cast<int>(arguments.m_priority), VX_FP_TASK, static_cast<size_t>(arguments.m_stackSize),
-        reinterpret_cast<FUNCPTR>(myRoutineWrapper), reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine),
-        reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine_argument), 0, 0, 0, 0, 0, 0, 0, 0);
+    int priority = arguments.m_priority;
+    if (arguments.m_priority == Os::Task::TASK_PRIORITY_DEFAULT) {
+        priority = 255;  // lowest priority
+    }
+
+    this->m_handle.m_task_descriptor =
+        taskCreate(taskName, priority, VX_FP_TASK, static_cast<size_t>(arguments.m_stackSize),
+                   reinterpret_cast<FUNCPTR>(myRoutineWrapper), reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine),
+                   reinterpret_cast<_Vx_usr_arg_t>(arguments.m_routine_argument), 0, 0, 0, 0, 0, 0, 0, 0);
 
     if (this->m_handle.m_task_descriptor == TASK_ID_NULL) {
         return Os::Task::Status::UNKNOWN_ERROR;
     }
 
 #ifdef _WRS_CONFIG_SMP
+    // when cpuAffinity is set to TASK_DEFAULT, the affinity will be assigned by the scheduler
     if (arguments.m_cpuAffinity != Os::Task::TASK_DEFAULT) {
         cpuset_t aff;
 


### PR DESCRIPTION
The default value for the stack queue is max U64. This results in failure to create the task, which returns an UNKNOWN_ERROR up the call stack and causes the SocketHelper to assert. I've added an additional check on the stack size. It returns an INVALID_STACK status, which is more clear than UNKNOWN_ERROR. Having this error status will help future users quickly discover their issue when they accidentally/implicitly use the default stack trace.