### PR TITLE
Update Queue implementation

### DIFF
--- a/VxWorks/Os/Queue.cpp
+++ b/VxWorks/Os/Queue.cpp
@@ -12,7 +12,14 @@ namespace VxWorks {
 namespace Queue {
 
 VxWorksQueue::~VxWorksQueue() {
-    (void)msgQDelete(this->m_handle.m_queue);
+    this->teardown();
+}
+
+void VxWorksQueue::teardown() {
+    if (this->m_handle.m_queue != MSG_Q_ID_NULL) {
+        (void)msgQDelete(this->m_handle.m_queue);
+        this->m_handle.m_queue = MSG_Q_ID_NULL;
+    }
 }
 
 QueueInterface::Status VxWorksQueue::create(FwEnumStoreType /*id*/, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) {

--- a/VxWorks/Os/Queue.hpp
+++ b/VxWorks/Os/Queue.hpp
@@ -48,6 +48,11 @@ class VxWorksQueue : public QueueInterface {
     //! \return: status of the creation
     Status create(FwEnumStoreType id, const Fw::ConstStringBase& name, FwSizeType depth, FwSizeType messageSize) override;
 
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown.
+    void teardown() override;
+
     //! \brief send a message into the queue
     //!
     //! Send a message into the queue, providing the message data, size, priority, and blocking type. When

--- a/cmake/platform/types/Platform/PlatformTypes.h
+++ b/cmake/platform/types/Platform/PlatformTypes.h
@@ -24,7 +24,7 @@ enum VxWorksConstants {
 	VXWORKS_READ = READ,
 	VXWORKS_OK = OK,
 	VXWORKS_NO_WAIT = NO_WAIT,
-        VXWORKS_NONE = NONE
+	VXWORKS_NONE = NONE
 };
 
 #undef OK
@@ -39,7 +39,7 @@ enum {
 	READ = VXWORKS_READ,
 	OK = VXWORKS_OK,
 	NO_WAIT = VXWORKS_NO_WAIT,
-        NONE = VXWORKS_NONE
+	NONE = VXWORKS_NONE
 };
 
 #include <inttypes.h>

--- a/cmake/platform/types/Platform/PlatformTypes.h
+++ b/cmake/platform/types/Platform/PlatformTypes.h
@@ -19,14 +19,29 @@ extern "C" {
 #include <vxWorks.h>
 
 // Capture current value of VxWorks constants
-enum VxWorksConstants { VXWORKS_ERROR = ERROR, VXWORKS_READ = READ, VXWORKS_OK = OK, VXWORKS_NO_WAIT = NO_WAIT };
+enum VxWorksConstants {
+	VXWORKS_ERROR = ERROR,
+	VXWORKS_READ = READ,
+	VXWORKS_OK = OK,
+	VXWORKS_NO_WAIT = NO_WAIT,
+        VXWORKS_NONE = NONE
+};
+
 #undef OK
 #undef ERROR
 #undef READ
 #undef NO_WAIT
+#undef NONE
 
 // Redefine constants as enumeration
-enum { ERROR = VXWORKS_ERROR, READ = VXWORKS_READ, OK = VXWORKS_OK, NO_WAIT = VXWORKS_NO_WAIT };
+enum {
+	ERROR = VXWORKS_ERROR,
+	READ = VXWORKS_READ,
+	OK = VXWORKS_OK,
+	NO_WAIT = VXWORKS_NO_WAIT,
+        NONE = VXWORKS_NONE
+};
+
 #include <inttypes.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Queue interface changed in latest fprime -- it added the teardown function. This PR implements that function. It also handles the macro-collision issue of `NONE` introduced by VxWorks