### PR TITLE
Added an Os::Queue implementation with per priority message sizing

### DIFF
--- a/VxWorks/Os/CMakeLists.txt
+++ b/VxWorks/Os/CMakeLists.txt
@@ -8,6 +8,29 @@
 restrict_platforms(vxworks)
 add_custom_target("${FPRIME_CURRENT_MODULE}")
 
+#### PriorityMemQueue VxWorks msgQ Implementation ####
+register_fprime_module(
+    Os_VxWorks_PriorityMemQueue_Implementation
+  SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/PriorityMemQueue.cpp"
+  HEADERS
+    "${CMAKE_CURRENT_LIST_DIR}/PriorityMemQueue.hpp"
+  DEPENDS
+    Fw_Types
+)
+
+register_fprime_implementation(
+    Os_VxWorks_PriorityMemQueue
+  SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/DefaultPriorityMemQueue.cpp"
+  IMPLEMENTS
+    Os_Queue
+  DEPENDS
+    Fw_Types
+    Os_VxWorks_PriorityMemQueue_Implementation
+)
+
+
 register_fprime_module(
     Os_VxWorks_Shared
   SOURCES

--- a/VxWorks/Os/DefaultPriorityMemQueue.cpp
+++ b/VxWorks/Os/DefaultPriorityMemQueue.cpp
@@ -1,0 +1,20 @@
+// ======================================================================
+// \title  Os/VxWorks/DefaultPriorityMemQueue.cpp
+// \author B. Duckett
+// \brief  cpp file sets default Os::Queue to VxWorks msgQ priority queue implementation via linker
+//
+// \copyright
+// Copyright 2026, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// ======================================================================
+#include "Os/Delegate.hpp"
+#include "Os/Queue.hpp"
+#include "PriorityMemQueue.hpp"
+
+namespace Os {
+QueueInterface* QueueInterface::getDelegate(QueueHandleStorage& aligned_new_memory) {
+    return Os::Delegate::makeDelegate<QueueInterface, Os::VxWorks::PriorityMemQueue, QueueHandleStorage>(
+        aligned_new_memory);
+}
+}  // namespace Os

--- a/VxWorks/Os/PriorityMemQueue.cpp
+++ b/VxWorks/Os/PriorityMemQueue.cpp
@@ -14,7 +14,6 @@
 #include <cstring>
 #include <limits>
 #include "Fw/LanguageHelpers.hpp"
-#include "Fw/Logger/Logger.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/MemAllocator.hpp"
 #include "config/MemoryAllocatorTypeEnumAc.hpp"
@@ -459,7 +458,6 @@ QueueInterface::Status PriorityMemQueue::createPriorityQueue(FwQueuePriorityType
     MSG_Q_ID msgQ = msgQCreate(static_cast<int>(numMsgs), static_cast<int>(maxMsgSize), MSG_Q_FIFO);
     
     if (msgQ == nullptr) {
-        Fw::Logger::log("ERROR: msgQCreate failed for priority %d\n", priority);
         this->teardownInternal();
         return Os::QueueInterface::Status::ALLOCATION_FAILED;
     }
@@ -486,9 +484,7 @@ void PriorityMemQueue::teardownInternal() {
             MSG_Q_ID msgQ = this->m_handle.m_msgQueues[i];
             if (msgQ != nullptr) {
                 STATUS status = msgQDelete(msgQ);
-                if (status != OK) {
-                    Fw::Logger::log("ERROR: msgQDelete failed for priority %lu\n", static_cast<unsigned long>(i));
-                }
+                FW_ASSERT(status == OK, this->m_handle.m_id, i);
                 this->m_handle.m_msgQueues[i] = nullptr;
                 this->m_handle.m_msgSizes[i] = 0;
                 this->m_handle.m_depths[i] = 0;
@@ -499,9 +495,7 @@ void PriorityMemQueue::teardownInternal() {
     // Delete the not-empty semaphore
     if (this->m_handle.m_notEmptySem != nullptr) {
         STATUS status = semDelete(this->m_handle.m_notEmptySem);
-        if (status != OK) {
-            Fw::Logger::log("ERROR: semDelete failed for not-empty semaphore\n");
-        }
+        FW_ASSERT(status == OK, this->m_handle.m_id);
         this->m_handle.m_notEmptySem = nullptr;
     }
 
@@ -552,8 +546,6 @@ QueueInterface::Status PriorityMemQueue::send(const U8* buffer,
         if (s_requirePrioritySizing) {
             FW_ASSERT(0, this->m_handle.m_id, s_requirePrioritySizing, priority);
         }
-        Fw::Logger::log("ERROR: Priority %d not found for %u, using default priority (%lu)\n", priority,
-                        this->m_handle.m_id, Os::VxWorks::Queue::DEFAULT_PRIORITY);
         priority = Os::VxWorks::Queue::DEFAULT_PRIORITY;
         msgQ = this->m_handle.m_msgQueues[priority];
     }

--- a/VxWorks/Os/PriorityMemQueue.cpp
+++ b/VxWorks/Os/PriorityMemQueue.cpp
@@ -44,19 +44,19 @@ static constexpr U32 priorityBitMask(FwQueuePriorityType priority) {
 }
 
 void PriorityMemQueueHandle::init() {
-    // Arrays must be allocated via allocateArrays() before init() is called
+    // If arrays were allocated, initialize them to safe default values 
     // Initialize all msgQ IDs to null if arrays are allocated
-    if (this->m_msgQueues != nullptr && this->m_msgSizes != nullptr && this->m_depths != nullptr) {
-        for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+    FwSizeType arraySize = static_cast<FwSizeType>(this->m_maxPriority) + 1;
+    if (this->m_msgQueues != nullptr && this->m_msgSizes != nullptr) {
+        for (FwSizeType i = 0; i < arraySize; ++i) {
             this->m_msgQueues[i] = nullptr;
             this->m_msgSizes[i] = 0;
-            this->m_depths[i] = 0;
         }
     }
 
     // Initialize high water marks to zero if array is allocated
     if (this->m_highWaterMarks != nullptr) {
-        for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+        for (FwSizeType i = 0; i < arraySize; ++i) {
             this->m_highWaterMarks[i].store(0, std::memory_order_relaxed);
         }
     }
@@ -73,27 +73,28 @@ void PriorityMemQueueHandle::init() {
 
     // Initialize atomic variables
     this->m_priorityMask.store(1U << Os::VxWorks::Queue::DEFAULT_PRIORITY, std::memory_order_relaxed);
-    this->m_numPriorities = 0;
 }
 
-bool PriorityMemQueueHandle::allocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId) {
-    // Store allocator ID for later deallocation
+bool PriorityMemQueueHandle::allocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId, FwQueuePriorityType maxPriority) {
+    // Store allocator ID and max priority for later use
     this->m_allocatorId = allocatorId;
+    this->m_maxPriority = maxPriority;
     
-    // Set max priorities to support
-    this->m_maxPriorities = Os::VxWorks::Queue::MAX_PRIORITIES;
+    // Calculate array size based on highest priority (0-indexed, so add 1)
+    FwSizeType arraySize = static_cast<FwSizeType>(maxPriority) + 1;
+    FW_ASSERT(arraySize <= Os::VxWorks::Queue::MAX_PRIORITIES, arraySize, Os::VxWorks::Queue::MAX_PRIORITIES);
     
     // Allocate memory for msgQueues array
-    FwSizeType msgQueuesSize = sizeof(MSG_Q_ID) * this->m_maxPriorities;
+    FwSizeType msgQueuesSize = sizeof(MSG_Q_ID) * arraySize;
     void* msgQueuesMem = allocator.checkedAllocate(allocatorId, msgQueuesSize, alignof(MSG_Q_ID));
     if (msgQueuesMem == nullptr) {
         return false;
     }
     // Use placement new to construct array
-    this->m_msgQueues = new (msgQueuesMem) MSG_Q_ID[this->m_maxPriorities];
+    this->m_msgQueues = new (msgQueuesMem) MSG_Q_ID[arraySize];
     
     // Allocate memory for msgSizes array
-    FwSizeType msgSizesSize = sizeof(FwSizeType) * this->m_maxPriorities;
+    FwSizeType msgSizesSize = sizeof(FwSizeType) * arraySize;
     void* msgSizesMem = allocator.checkedAllocate(allocatorId, msgSizesSize, alignof(FwSizeType));
     if (msgSizesMem == nullptr) {
         allocator.deallocate(allocatorId, this->m_msgQueues);
@@ -101,36 +102,21 @@ bool PriorityMemQueueHandle::allocateArrays(Fw::MemAllocator& allocator, FwEnumS
         return false;
     }
     // Use placement new to construct array
-    this->m_msgSizes = new (msgSizesMem) FwSizeType[this->m_maxPriorities];
-    
-    // Allocate memory for depths array
-    FwSizeType depthsSize = sizeof(FwSizeType) * this->m_maxPriorities;
-    void* depthsMem = allocator.checkedAllocate(allocatorId, depthsSize, alignof(FwSizeType));
-    if (depthsMem == nullptr) {
-        allocator.deallocate(allocatorId, this->m_msgQueues);
-        allocator.deallocate(allocatorId, this->m_msgSizes);
-        this->m_msgQueues = nullptr;
-        this->m_msgSizes = nullptr;
-        return false;
-    }
-    // Use placement new to construct array
-    this->m_depths = new (depthsMem) FwSizeType[this->m_maxPriorities];
+    this->m_msgSizes = new (msgSizesMem) FwSizeType[arraySize];
     
     // Allocate memory for highWaterMarks array
-    FwSizeType hwmSize = sizeof(std::atomic<U32>) * this->m_maxPriorities;
+    FwSizeType hwmSize = sizeof(std::atomic<U32>) * arraySize;
     void* hwmMem = allocator.checkedAllocate(allocatorId, hwmSize, alignof(std::atomic<U32>));
     if (hwmMem == nullptr) {
         allocator.deallocate(allocatorId, this->m_msgQueues);
         allocator.deallocate(allocatorId, this->m_msgSizes);
-        allocator.deallocate(allocatorId, this->m_depths);
         this->m_msgQueues = nullptr;
         this->m_msgSizes = nullptr;
-        this->m_depths = nullptr;
         return false;
     }
     // Use placement new to construct array of atomics
     this->m_highWaterMarks = reinterpret_cast<std::atomic<U32>*>(hwmMem);
-    for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+    for (FwSizeType i = 0; i < arraySize; ++i) {
         new (&this->m_highWaterMarks[i]) std::atomic<U32>(0);
     }
     
@@ -139,17 +125,14 @@ bool PriorityMemQueueHandle::allocateArrays(Fw::MemAllocator& allocator, FwEnumS
 
 void PriorityMemQueueHandle::deallocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId) {
     // Deallocate arrays in reverse order using stored allocator ID
+    FwSizeType arraySize = static_cast<FwSizeType>(this->m_maxPriority) + 1;
     if (this->m_highWaterMarks != nullptr) {
         // Explicitly destroy atomics before deallocation
-        for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+        for (FwSizeType i = 0; i < arraySize; ++i) {
             this->m_highWaterMarks[i].~atomic();
         }
         allocator.deallocate(allocatorId, this->m_highWaterMarks);
         this->m_highWaterMarks = nullptr;
-    }
-    if (this->m_depths != nullptr) {
-        allocator.deallocate(allocatorId, this->m_depths);
-        this->m_depths = nullptr;
     }
     if (this->m_msgSizes != nullptr) {
         allocator.deallocate(allocatorId, this->m_msgSizes);
@@ -159,12 +142,14 @@ void PriorityMemQueueHandle::deallocateArrays(Fw::MemAllocator& allocator, FwEnu
         allocator.deallocate(allocatorId, this->m_msgQueues);
         this->m_msgQueues = nullptr;
     }
-    this->m_maxPriorities = 0;
+    this->m_maxPriority = 0;
     this->m_allocatorId = 0;
 }
 
 void PriorityMemQueueHandle::enablePriority(FwQueuePriorityType priority) {
-    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_id);
+    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, priority, this->m_id);
+    // Enabling a priority is only allowed if it's in use  
+    FW_ASSERT(this->m_msgQueues != nullptr && this->m_msgQueues[priority] != nullptr, this->m_id, priority);
 
     // MEMORY ORDERING: seq_cst for control path operations ensures total ordering
     // Atomic update of priority mask using fetch_or with seq_cst (control path)
@@ -266,7 +251,8 @@ void PriorityMemQueue::configure(QueueConfig* queueConfigs, FwSizeType numQueueC
             QueueConfig* currentConfig = &queueConfigs[i];
 
             // Assert if numPriorities is 0
-            FW_ASSERT(currentConfig->numPriorities > 0, static_cast<FwAssertArgType>(i), currentConfig->instanceId);
+            FW_ASSERT(currentConfig->numPriorities > 0 && currentConfig->numPriorities <= Os::VxWorks::Queue::MAX_PRIORITIES,
+                      static_cast<FwAssertArgType>(i), currentConfig->instanceId, static_cast<FwAssertArgType>(currentConfig->numPriorities));
 
             // Check for duplicate instance IDs
             for (FwSizeType j = i + 1; j < numQueueConfigs; ++j) {
@@ -277,6 +263,7 @@ void PriorityMemQueue::configure(QueueConfig* queueConfigs, FwSizeType numQueueC
 
             // Check priority configurations
             QueuePriorityConfig* priorityConfigs = currentConfig->priorityConfigs;
+            FW_ASSERT(priorityConfigs != nullptr, static_cast<FwAssertArgType>(i), currentConfig->instanceId, currentConfig->numPriorities);
             for (FwSizeType p = 0; p < currentConfig->numPriorities; ++p) {
                 QueuePriorityConfig* pConfig = &priorityConfigs[p];
 
@@ -361,16 +348,27 @@ QueueInterface::Status PriorityMemQueue::create(FwEnumStoreType id,
     // Get the memory allocator for queue operations
     Fw::MemAllocator& allocator = this->getAllocator();
     
-    // Allocate arrays for priority data
-    if (!this->m_handle.allocateArrays(allocator, id)) {
+    // Find a matching configuration if one exists
+    QueueConfig* queueConfig = findMatchingConfig(id);
+
+    // Calculate maxPriority needed
+    FwQueuePriorityType maxPriority = Os::VxWorks::Queue::DEFAULT_PRIORITY;
+    if (queueConfig != nullptr) {
+        // Find highest priority in configuration
+        for (FwSizeType i = 0; i < queueConfig->numPriorities; ++i) {
+            if (queueConfig->priorityConfigs[i].priority > maxPriority) {
+                maxPriority = queueConfig->priorityConfigs[i].priority;
+            }
+        }
+    }
+    
+    // Allocate arrays for priority data based on maxPriority
+    if (!this->m_handle.allocateArrays(allocator, id, maxPriority)) {
         return Os::QueueInterface::Status::ALLOCATION_FAILED;
     }
     
     // Initialize the handle with allocated arrays
     this->m_handle.init();
-
-    // Find a matching configuration if one exists
-    QueueConfig* queueConfig = findMatchingConfig(id);
 
     // Create the priority queues based on configuration
     if (queueConfig != nullptr) {
@@ -409,8 +407,6 @@ QueueInterface::Status PriorityMemQueue::createConfiguredQueues(QueueConfig* que
                                                                 FwEnumStoreType allocatorId) {
     FW_ASSERT(queueConfig != nullptr, this->m_handle.m_id);
     FW_ASSERT(queueConfig->priorityConfigs != nullptr, this->m_handle.m_id, queueConfig->numPriorities);
-    
-    this->m_handle.m_numPriorities = static_cast<U32>(queueConfig->numPriorities);
 
     for (FwSizeType i = 0; i < queueConfig->numPriorities; ++i) {
         const QueuePriorityConfig& priorityConfig = queueConfig->priorityConfigs[i];
@@ -436,8 +432,6 @@ QueueInterface::Status PriorityMemQueue::createDefaultQueue(FwSizeType depth,
                                                             FwSizeType messageSize,
                                                             Fw::MemAllocator& allocator,
                                                             FwEnumStoreType allocatorId) {
-    this->m_handle.m_numPriorities = 1;
-
     // Create and initialize the default priority queue
     return this->createPriorityQueue(Os::VxWorks::Queue::DEFAULT_PRIORITY, messageSize, depth, allocator, allocatorId);
 }
@@ -450,8 +444,8 @@ QueueInterface::Status PriorityMemQueue::createPriorityQueue(FwQueuePriorityType
                                                              FwEnumStoreType allocatorId) {
     FW_ASSERT(this->m_handle.m_msgQueues != nullptr, this->m_handle.m_id, priority);
     FW_ASSERT(this->m_handle.m_msgSizes != nullptr, this->m_handle.m_id, priority);
-    FW_ASSERT(this->m_handle.m_depths != nullptr, this->m_handle.m_id, priority);
     FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_handle.m_id, priority);
+    FW_ASSERT(priority <= this->m_handle.m_maxPriority, this->m_handle.m_id, priority, this->m_handle.m_maxPriority);
     
     // Create VxWorks message queue
     // MSG_Q_FIFO ensures FIFO ordering within this priority level
@@ -465,7 +459,6 @@ QueueInterface::Status PriorityMemQueue::createPriorityQueue(FwQueuePriorityType
     // Store the msgQ handle and configuration
     this->m_handle.m_msgQueues[priority] = msgQ;
     this->m_handle.m_msgSizes[priority] = maxMsgSize;
-    this->m_handle.m_depths[priority] = numMsgs;
 
     return Os::QueueInterface::Status::OP_OK;
 }
@@ -480,14 +473,14 @@ void PriorityMemQueue::teardownInternal() {
     
     // Delete all VxWorks message queues if arrays are allocated
     if (this->m_handle.m_msgQueues != nullptr) {
-        for (FwSizeType i = 0; i < this->m_handle.m_maxPriorities; ++i) {
+        FwSizeType arraySize = static_cast<FwSizeType>(this->m_handle.m_maxPriority) + 1;
+        for (FwSizeType i = 0; i < arraySize; ++i) {
             MSG_Q_ID msgQ = this->m_handle.m_msgQueues[i];
             if (msgQ != nullptr) {
                 STATUS status = msgQDelete(msgQ);
                 FW_ASSERT(status == OK, this->m_handle.m_id, i);
                 this->m_handle.m_msgQueues[i] = nullptr;
                 this->m_handle.m_msgSizes[i] = 0;
-                this->m_handle.m_depths[i] = 0;
             }
         }
     }
@@ -500,7 +493,6 @@ void PriorityMemQueue::teardownInternal() {
     }
 
     // Reset handle state
-    this->m_handle.m_numPriorities = 0;
     this->m_handle.m_priorityMask.store(1U << Os::VxWorks::Queue::DEFAULT_PRIORITY, std::memory_order_relaxed);
 
     // Deallocate arrays using stored allocator ID
@@ -536,9 +528,10 @@ QueueInterface::Status PriorityMemQueue::send(const U8* buffer,
     }
 
     // Check if the queue is initialized
-    if (this->m_handle.m_numPriorities == 0 || this->m_handle.m_msgQueues == nullptr) {
+    if (this->m_handle.m_msgQueues == nullptr) {
         return QueueInterface::Status::UNINITIALIZED;
     }
+    FW_ASSERT(this->m_handle.m_msgSizes != nullptr, this->m_handle.m_id, priority);
 
     // Check if the priority queue exists - no fallback, fail fast
     MSG_Q_ID msgQ = this->m_handle.m_msgQueues[priority];
@@ -549,7 +542,7 @@ QueueInterface::Status PriorityMemQueue::send(const U8* buffer,
         priority = Os::VxWorks::Queue::DEFAULT_PRIORITY;
         msgQ = this->m_handle.m_msgQueues[priority];
     }
-    FW_ASSERT(msgQ != nullptr, this->m_handle.m_id, priority, this->m_handle.m_numPriorities);
+    FW_ASSERT(msgQ != nullptr, this->m_handle.m_id, priority);
 
     // Check for sizing problem
     if (size > this->m_handle.m_msgSizes[priority]) {
@@ -605,7 +598,7 @@ QueueInterface::Status PriorityMemQueue::receive(U8* destination,
     FW_ASSERT(destination != nullptr, blockType, this->m_handle.m_id);
 
     // Check if the queue is initialized
-    if (this->m_handle.m_numPriorities == 0 || this->m_handle.m_msgQueues == nullptr) {
+    if (this->m_handle.m_msgQueues == nullptr) {
         return QueueInterface::Status::UNINITIALIZED;
     }
 
@@ -640,12 +633,10 @@ QueueInterface::Status PriorityMemQueue::receive(U8* destination,
             if ((enabledPriorities & priorityBitMask(testPriority)) == 0) {
                 continue;
             }
-            
+            // Validate message queue is not a null pointer (if the priority is enabled, the queue must exist)
             FW_ASSERT(this->m_handle.m_msgQueues != nullptr, this->m_handle.m_id, testPriority);
             MSG_Q_ID msgQ = this->m_handle.m_msgQueues[testPriority];
-            if (msgQ == nullptr) {
-                continue;
-            }
+            FW_ASSERT(msgQ != nullptr, this->m_handle.m_id, testPriority);
             
             // Try to receive with NO_WAIT (non-blocking within this attempt)
             int bytesRead = msgQReceive(msgQ, reinterpret_cast<char*>(destination), 
@@ -680,7 +671,8 @@ FwSizeType PriorityMemQueue::getMessagesAvailable() const {
     FwSizeType total = 0;
 
     if (this->m_handle.m_msgQueues != nullptr) {
-        for (FwSizeType i = 0; i < this->m_handle.m_maxPriorities; ++i) {
+        FwSizeType arraySize = static_cast<FwSizeType>(this->m_handle.m_maxPriority) + 1;
+        for (FwSizeType i = 0; i < arraySize; ++i) {
             MSG_Q_ID msgQ = this->m_handle.m_msgQueues[i];
             if (msgQ != nullptr) {
                 int numMsgs = msgQNumMsgs(msgQ);
@@ -697,7 +689,8 @@ FwSizeType PriorityMemQueue::getMessageHighWaterMark() const {
     // MEMORY ORDERING: Use acquire to ensure visibility of latest HWM updates
     U32 maxHwm = 0;
     if (this->m_handle.m_highWaterMarks != nullptr) {
-        for (FwSizeType i = 0; i < this->m_handle.m_maxPriorities; ++i) {
+        FwSizeType arraySize = static_cast<FwSizeType>(this->m_handle.m_maxPriority) + 1;
+        for (FwSizeType i = 0; i < arraySize; ++i) {
             U32 hwm = this->m_handle.m_highWaterMarks[i].load(std::memory_order_acquire);
             if (hwm > maxHwm) {
                 maxHwm = hwm;

--- a/VxWorks/Os/PriorityMemQueue.cpp
+++ b/VxWorks/Os/PriorityMemQueue.cpp
@@ -1,0 +1,723 @@
+// ======================================================================
+// \title  Os/VxWorks/PriorityMemQueue.cpp
+// \author B. Duckett
+// \brief  cpp file for VxWorks msgQ-based priority queue implementation for Os::Queue
+//
+// \copyright
+// Copyright 2026, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// ======================================================================
+#include "PriorityMemQueue.hpp"
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include "Fw/LanguageHelpers.hpp"
+#include "Fw/Logger/Logger.hpp"
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/MemAllocator.hpp"
+#include "config/MemoryAllocatorTypeEnumAc.hpp"
+#include <vxWorks.h>
+#include <msgQLib.h>
+#include <semLib.h>
+#include <intLib.h>
+
+namespace Os {
+namespace VxWorks {
+
+// Arbitrary (but small) limit to prevent infinite loops
+// Don't expect a message queue depth to ever exceed three digits
+constexpr U32 LOOP_GUARD_LIMIT = 2000;
+
+// Initialize static members
+PriorityMemQueue::QueueConfig* PriorityMemQueue::s_configs = nullptr;
+FwSizeType PriorityMemQueue::s_numConfigs = 0;
+bool PriorityMemQueue::s_requirePrioritySizing = false;
+std::atomic<bool>* PriorityMemQueue::s_configsUsed = nullptr;
+bool PriorityMemQueue::s_configured = false;
+
+//! \brief Get the bit mask for a priority
+//! \param priority: priority to get mask for
+//! \return bit mask with the priority bit set
+static constexpr U32 priorityBitMask(FwQueuePriorityType priority) {
+    return 1U << priority;
+}
+
+void PriorityMemQueueHandle::init() {
+    // Arrays must be allocated via allocateArrays() before init() is called
+    // Initialize all msgQ IDs to null if arrays are allocated
+    if (this->m_msgQueues != nullptr && this->m_msgSizes != nullptr && this->m_depths != nullptr) {
+        for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+            this->m_msgQueues[i] = nullptr;
+            this->m_msgSizes[i] = 0;
+            this->m_depths[i] = 0;
+        }
+    }
+
+    // Initialize high water marks to zero if array is allocated
+    if (this->m_highWaterMarks != nullptr) {
+        for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+            this->m_highWaterMarks[i].store(0, std::memory_order_relaxed);
+        }
+    }
+
+    // Initialize the not-empty semaphore with count 0 (queue starts empty)
+    // Delete old semaphore if it exists
+    if (this->m_notEmptySem != nullptr) {
+        STATUS status = semDelete(this->m_notEmptySem);
+        FW_ASSERT(status == OK, status);
+    }
+    // Create VxWorks counting semaphore with initial count 0
+    this->m_notEmptySem = semCCreate(SEM_Q_FIFO, 0);
+    FW_ASSERT(this->m_notEmptySem != nullptr, 0);
+
+    // Initialize atomic variables
+    this->m_priorityMask.store(1U << Os::VxWorks::Queue::DEFAULT_PRIORITY, std::memory_order_relaxed);
+    this->m_numPriorities = 0;
+}
+
+bool PriorityMemQueueHandle::allocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId) {
+    // Store allocator ID for later deallocation
+    this->m_allocatorId = allocatorId;
+    
+    // Set max priorities to support
+    this->m_maxPriorities = Os::VxWorks::Queue::MAX_PRIORITIES;
+    
+    // Allocate memory for msgQueues array
+    FwSizeType msgQueuesSize = sizeof(MSG_Q_ID) * this->m_maxPriorities;
+    void* msgQueuesMem = allocator.checkedAllocate(allocatorId, msgQueuesSize, alignof(MSG_Q_ID));
+    if (msgQueuesMem == nullptr) {
+        return false;
+    }
+    // Use placement new to construct array
+    this->m_msgQueues = new (msgQueuesMem) MSG_Q_ID[this->m_maxPriorities];
+    
+    // Allocate memory for msgSizes array
+    FwSizeType msgSizesSize = sizeof(FwSizeType) * this->m_maxPriorities;
+    void* msgSizesMem = allocator.checkedAllocate(allocatorId, msgSizesSize, alignof(FwSizeType));
+    if (msgSizesMem == nullptr) {
+        allocator.deallocate(allocatorId, this->m_msgQueues);
+        this->m_msgQueues = nullptr;
+        return false;
+    }
+    // Use placement new to construct array
+    this->m_msgSizes = new (msgSizesMem) FwSizeType[this->m_maxPriorities];
+    
+    // Allocate memory for depths array
+    FwSizeType depthsSize = sizeof(FwSizeType) * this->m_maxPriorities;
+    void* depthsMem = allocator.checkedAllocate(allocatorId, depthsSize, alignof(FwSizeType));
+    if (depthsMem == nullptr) {
+        allocator.deallocate(allocatorId, this->m_msgQueues);
+        allocator.deallocate(allocatorId, this->m_msgSizes);
+        this->m_msgQueues = nullptr;
+        this->m_msgSizes = nullptr;
+        return false;
+    }
+    // Use placement new to construct array
+    this->m_depths = new (depthsMem) FwSizeType[this->m_maxPriorities];
+    
+    // Allocate memory for highWaterMarks array
+    FwSizeType hwmSize = sizeof(std::atomic<U32>) * this->m_maxPriorities;
+    void* hwmMem = allocator.checkedAllocate(allocatorId, hwmSize, alignof(std::atomic<U32>));
+    if (hwmMem == nullptr) {
+        allocator.deallocate(allocatorId, this->m_msgQueues);
+        allocator.deallocate(allocatorId, this->m_msgSizes);
+        allocator.deallocate(allocatorId, this->m_depths);
+        this->m_msgQueues = nullptr;
+        this->m_msgSizes = nullptr;
+        this->m_depths = nullptr;
+        return false;
+    }
+    // Use placement new to construct array of atomics
+    this->m_highWaterMarks = reinterpret_cast<std::atomic<U32>*>(hwmMem);
+    for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+        new (&this->m_highWaterMarks[i]) std::atomic<U32>(0);
+    }
+    
+    return true;
+}
+
+void PriorityMemQueueHandle::deallocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId) {
+    // Deallocate arrays in reverse order using stored allocator ID
+    if (this->m_highWaterMarks != nullptr) {
+        // Explicitly destroy atomics before deallocation
+        for (FwSizeType i = 0; i < this->m_maxPriorities; ++i) {
+            this->m_highWaterMarks[i].~atomic();
+        }
+        allocator.deallocate(allocatorId, this->m_highWaterMarks);
+        this->m_highWaterMarks = nullptr;
+    }
+    if (this->m_depths != nullptr) {
+        allocator.deallocate(allocatorId, this->m_depths);
+        this->m_depths = nullptr;
+    }
+    if (this->m_msgSizes != nullptr) {
+        allocator.deallocate(allocatorId, this->m_msgSizes);
+        this->m_msgSizes = nullptr;
+    }
+    if (this->m_msgQueues != nullptr) {
+        allocator.deallocate(allocatorId, this->m_msgQueues);
+        this->m_msgQueues = nullptr;
+    }
+    this->m_maxPriorities = 0;
+    this->m_allocatorId = 0;
+}
+
+void PriorityMemQueueHandle::enablePriority(FwQueuePriorityType priority) {
+    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_id);
+
+    // MEMORY ORDERING: seq_cst for control path operations ensures total ordering
+    // Atomic update of priority mask using fetch_or with seq_cst (control path)
+    this->m_priorityMask.fetch_or(priorityBitMask(priority), std::memory_order_seq_cst);
+}
+
+void PriorityMemQueueHandle::disablePriority(FwQueuePriorityType priority) {
+    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_id);
+
+    // MEMORY ORDERING: seq_cst for control path operations ensures total ordering
+    // Atomic update of priority mask using fetch_and with seq_cst (control path)
+    this->m_priorityMask.fetch_and(~priorityBitMask(priority), std::memory_order_seq_cst);
+}
+
+PriorityMemQueue::PriorityMemQueue() {
+    // Initialize handle to safe defaults
+    this->m_handle.init();
+}
+
+//! \brief Find most significant bit set (IPC-style priority finding)
+//! \param value: bit mask to search
+//! \return bit position of MSB, or -1 if no bits set
+static inline I32 findMSB(U32 value) {
+    if (value == 0) {
+        return -1;
+    }
+    // Use compiler builtin for CLZ (count leading zeros) if available
+#if defined(__GNUC__) || defined(__clang__)
+    return 31 - __builtin_clz(value);
+#else
+    // Fallback: software implementation
+    I32 msb = 31;
+    U32 mask = 0x80000000;
+    while (mask && !(mask & value)) {
+        --msb;
+        mask >>= 1;
+    }
+    return msb;
+#endif
+}
+
+FwQueuePriorityType PriorityMemQueue::findHighestPriority(U32 priorities) {
+    // MEMORY ORDERING: Use acquire to synchronize with priority enable/disable operations
+    // Get enabled priorities
+    if (priorities == 0) {
+        priorities = this->m_handle.m_priorityMask.load(std::memory_order_acquire);
+    }
+
+    if (priorities == 0) {
+        return Os::VxWorks::Queue::MAX_PRIORITIES;
+    }
+
+    // Use IPC-style MSB finding for performance
+    I32 msb = findMSB(priorities);
+    if (msb < 0 || msb >= static_cast<I32>(Os::VxWorks::Queue::MAX_PRIORITIES)) {
+        return Os::VxWorks::Queue::MAX_PRIORITIES;
+    }
+    return static_cast<FwQueuePriorityType>(msb);
+}
+
+bool PriorityMemQueue::isPriorityEnabled(FwQueuePriorityType priority) {
+    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_handle.m_id);
+
+    return (this->m_handle.m_priorityMask.load(std::memory_order_seq_cst) & priorityBitMask(priority)) != 0;
+}
+
+void PriorityMemQueue::setPriorityEnabled(FwQueuePriorityType priority, bool enabled) {
+    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_handle.m_id);
+
+    // MEMORY ORDERING: seq_cst for control path, acquire for data path (see receive())
+    // Atomic update of priority mask using fetch_or/fetch_and with seq_cst (control path)
+    if (enabled) {
+        this->m_handle.m_priorityMask.fetch_or(priorityBitMask(priority), std::memory_order_seq_cst);
+    } else {
+        this->m_handle.m_priorityMask.fetch_and(~priorityBitMask(priority), std::memory_order_seq_cst);
+    }
+}
+
+Fw::MemAllocator& PriorityMemQueue::getAllocator() {
+    return Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
+        Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+}
+
+void PriorityMemQueue::configure(QueueConfig* queueConfigs, FwSizeType numQueueConfigs, bool required, FwEnumStoreType allocatorId) {
+    // Accept NULL pointer if and only if numQueueConfigs is 0
+    FW_ASSERT((queueConfigs != nullptr) || (numQueueConfigs == 0), 0);
+
+    // Assert if already configured - that's not a supported use case
+    FW_ASSERT(!s_configured, 0);
+
+    s_configured = true;
+
+    // Assert if required is true but num priorities is 0
+    FW_ASSERT(!(required && numQueueConfigs == 0), required, static_cast<FwAssertArgType>(numQueueConfigs));
+
+    // Check for duplicate instance IDs and invalid configurations
+    if (queueConfigs != nullptr) {
+        for (FwSizeType i = 0; i < numQueueConfigs; ++i) {
+            QueueConfig* currentConfig = &queueConfigs[i];
+
+            // Assert if numPriorities is 0
+            FW_ASSERT(currentConfig->numPriorities > 0, static_cast<FwAssertArgType>(i), currentConfig->instanceId);
+
+            // Check for duplicate instance IDs
+            for (FwSizeType j = i + 1; j < numQueueConfigs; ++j) {
+                QueueConfig* otherConfig = &queueConfigs[j];
+                FW_ASSERT(currentConfig->instanceId != otherConfig->instanceId, currentConfig->instanceId,
+                          static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(j));
+            }
+
+            // Check priority configurations
+            QueuePriorityConfig* priorityConfigs = currentConfig->priorityConfigs;
+            for (FwSizeType p = 0; p < currentConfig->numPriorities; ++p) {
+                QueuePriorityConfig* pConfig = &priorityConfigs[p];
+
+                // Assert if maxMsgSize or numMsgs is 0
+                FW_ASSERT(pConfig->maxMsgSize > 0, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(p),
+                          pConfig->priority);
+                FW_ASSERT(pConfig->numMsgs > 0, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(p),
+                          pConfig->priority);
+                FW_ASSERT(pConfig->priority >= 0 && pConfig->priority < Os::VxWorks::Queue::MAX_PRIORITIES,
+                          static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(p), pConfig->priority);
+
+                // Check for duplicate priority values
+                for (FwSizeType q = p + 1; q < currentConfig->numPriorities; ++q) {
+                    QueuePriorityConfig* qConfig = &priorityConfigs[q];
+                    FW_ASSERT(pConfig->priority != qConfig->priority, static_cast<FwAssertArgType>(i),
+                              currentConfig->instanceId, pConfig->priority);
+                }
+            }
+        }
+    }
+    // Get the memory allocator configured for priority queues
+    // NOTE: This dynamic memory is intentionally never freed in production because configure()
+    //       is called once and only once during system initialization (enforced by s_configured check).
+    //       In test environments, test harnesses should explicitly call destructors before deallocating
+    //       to prevent memory leaks (see PriorityMemQueueTestHelper::resetConfig() for example).
+    // Note: This is a static method so we can't use getAllocator() instance method
+    // Note: Initialization is single threaded, so using atomics here is _probably_ overkill 
+    Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
+        Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+    // Allocate memory for tracking used configurations
+    if (numQueueConfigs > 0) {
+        FwSizeType expSize = numQueueConfigs * sizeof(std::atomic<bool>);
+        s_configsUsed = reinterpret_cast<std::atomic<bool>*>(
+            allocator.checkedAllocate(allocatorId, expSize, alignof(std::atomic<bool>)));
+        FW_ASSERT(s_configsUsed != nullptr);
+        // Initialize all entries to false using placement new
+        for (FwSizeType i = 0; i < numQueueConfigs; ++i) {
+            new (&s_configsUsed[i]) std::atomic<bool>(false);
+        }
+    }
+
+    // Store configuration
+    s_configs = queueConfigs;
+    s_numConfigs = numQueueConfigs;
+    s_requirePrioritySizing = required;
+}
+
+void PriorityMemQueue::resetConfig() {
+    // Only call this in test environments after all queues are destroyed
+    if (s_configsUsed != nullptr) {
+        // Get allocator (same as used in config())
+        Fw::MemAllocator& allocator = Fw::MemAllocatorRegistry::getInstance().getAnAllocator(
+            Fw::MemoryAllocation::MemoryAllocatorType::OS_GENERIC_PRIORITY_QUEUE);
+        FwEnumStoreType allocatorId = 0;
+        
+        // Deallocate the tracking array
+        allocator.deallocate(allocatorId, s_configsUsed);
+        s_configsUsed = nullptr;
+    }
+    
+    // Reset all static state
+    s_configs = nullptr;
+    s_numConfigs = 0;
+    s_requirePrioritySizing = false;
+    s_configured = false;
+}
+
+PriorityMemQueue::~PriorityMemQueue() {
+    this->teardownInternal();
+}
+
+QueueInterface::Status PriorityMemQueue::create(FwEnumStoreType id,
+                                                const Fw::ConstStringBase& name,
+                                                FwSizeType depth,
+                                                FwSizeType messageSize) {
+    FW_ASSERT(depth > 0, id);
+    FW_ASSERT(messageSize > 0, id);
+
+    // Initialize the handle ID
+    this->m_handle.m_id = id;
+
+    // Get the memory allocator for queue operations
+    Fw::MemAllocator& allocator = this->getAllocator();
+    
+    // Allocate arrays for priority data
+    if (!this->m_handle.allocateArrays(allocator, id)) {
+        return Os::QueueInterface::Status::ALLOCATION_FAILED;
+    }
+    
+    // Initialize the handle with allocated arrays
+    this->m_handle.init();
+
+    // Find a matching configuration if one exists
+    QueueConfig* queueConfig = findMatchingConfig(id);
+
+    // Create the priority queues based on configuration
+    if (queueConfig != nullptr) {
+        // Use the found configuration to create multiple priority queues
+        return createConfiguredQueues(queueConfig, allocator, id);
+    } else {
+        // No configuration found, create a single default priority queue
+        return createDefaultQueue(depth, messageSize, allocator, id);
+    }
+}
+
+// Helper method to find a matching configuration for the given ID
+PriorityMemQueue::QueueConfig* PriorityMemQueue::findMatchingConfig(FwEnumStoreType id) {
+    
+    if (s_configs != nullptr && s_configsUsed != nullptr) {
+        
+        for (FwSizeType i = 0; i < s_numConfigs; ++i) {
+            if (s_configs[i].instanceId == id) {
+                // Atomic check-and-set to claim configuration
+                bool expected = false;
+                if (s_configsUsed[i].compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+                    return &s_configs[i];
+                } else {
+                    // Configuration already in use, assert failure
+                    FW_ASSERT(false, id, s_configs[i].instanceId);
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+// Helper method to create queues based on configuration
+QueueInterface::Status PriorityMemQueue::createConfiguredQueues(QueueConfig* queueConfig,
+                                                                Fw::MemAllocator& allocator,
+                                                                FwEnumStoreType allocatorId) {
+    FW_ASSERT(queueConfig != nullptr, this->m_handle.m_id);
+    FW_ASSERT(queueConfig->priorityConfigs != nullptr, this->m_handle.m_id, queueConfig->numPriorities);
+    
+    this->m_handle.m_numPriorities = static_cast<U32>(queueConfig->numPriorities);
+
+    for (FwSizeType i = 0; i < queueConfig->numPriorities; ++i) {
+        const QueuePriorityConfig& priorityConfig = queueConfig->priorityConfigs[i];
+        FwQueuePriorityType priority = priorityConfig.priority;
+
+        // Create and initialize the priority queue
+        QueueInterface::Status status =
+            this->createPriorityQueue(priority, priorityConfig.maxMsgSize, priorityConfig.numMsgs, allocator, allocatorId);
+
+        if (status != Os::QueueInterface::Status::OP_OK) {
+            return status;
+        }
+
+        // Enable this priority
+        this->setPriorityEnabled(priority, true);
+    }
+
+    return Os::QueueInterface::Status::OP_OK;
+}
+
+// Helper method to create a single default priority queue
+QueueInterface::Status PriorityMemQueue::createDefaultQueue(FwSizeType depth,
+                                                            FwSizeType messageSize,
+                                                            Fw::MemAllocator& allocator,
+                                                            FwEnumStoreType allocatorId) {
+    this->m_handle.m_numPriorities = 1;
+
+    // Create and initialize the default priority queue
+    return this->createPriorityQueue(Os::VxWorks::Queue::DEFAULT_PRIORITY, messageSize, depth, allocator, allocatorId);
+}
+
+// Helper method to create a single priority queue using VxWorks msgQ
+QueueInterface::Status PriorityMemQueue::createPriorityQueue(FwQueuePriorityType priority,
+                                                             FwSizeType maxMsgSize,
+                                                             FwSizeType numMsgs,
+                                                             Fw::MemAllocator& allocator,
+                                                             FwEnumStoreType allocatorId) {
+    FW_ASSERT(this->m_handle.m_msgQueues != nullptr, this->m_handle.m_id, priority);
+    FW_ASSERT(this->m_handle.m_msgSizes != nullptr, this->m_handle.m_id, priority);
+    FW_ASSERT(this->m_handle.m_depths != nullptr, this->m_handle.m_id, priority);
+    FW_ASSERT(priority < Os::VxWorks::Queue::MAX_PRIORITIES, this->m_handle.m_id, priority);
+    
+    // Create VxWorks message queue
+    // MSG_Q_FIFO ensures FIFO ordering within this priority level
+    MSG_Q_ID msgQ = msgQCreate(static_cast<int>(numMsgs), static_cast<int>(maxMsgSize), MSG_Q_FIFO);
+    
+    if (msgQ == nullptr) {
+        Fw::Logger::log("ERROR: msgQCreate failed for priority %d\n", priority);
+        this->teardownInternal();
+        return Os::QueueInterface::Status::ALLOCATION_FAILED;
+    }
+    
+    // Store the msgQ handle and configuration
+    this->m_handle.m_msgQueues[priority] = msgQ;
+    this->m_handle.m_msgSizes[priority] = maxMsgSize;
+    this->m_handle.m_depths[priority] = numMsgs;
+
+    return Os::QueueInterface::Status::OP_OK;
+}
+
+void PriorityMemQueue::teardown() {
+    this->teardownInternal();
+}
+
+void PriorityMemQueue::teardownInternal() {
+    // NOTE: This function is intended for use in unit tests or single-threaded teardown.
+    //       Thread safety is not guaranteed for concurrent teardown operations.
+    
+    // Delete all VxWorks message queues if arrays are allocated
+    if (this->m_handle.m_msgQueues != nullptr) {
+        for (FwSizeType i = 0; i < this->m_handle.m_maxPriorities; ++i) {
+            MSG_Q_ID msgQ = this->m_handle.m_msgQueues[i];
+            if (msgQ != nullptr) {
+                STATUS status = msgQDelete(msgQ);
+                if (status != OK) {
+                    Fw::Logger::log("ERROR: msgQDelete failed for priority %lu\n", static_cast<unsigned long>(i));
+                }
+                this->m_handle.m_msgQueues[i] = nullptr;
+                this->m_handle.m_msgSizes[i] = 0;
+                this->m_handle.m_depths[i] = 0;
+            }
+        }
+    }
+
+    // Delete the not-empty semaphore
+    if (this->m_handle.m_notEmptySem != nullptr) {
+        STATUS status = semDelete(this->m_handle.m_notEmptySem);
+        if (status != OK) {
+            Fw::Logger::log("ERROR: semDelete failed for not-empty semaphore\n");
+        }
+        this->m_handle.m_notEmptySem = nullptr;
+    }
+
+    // Reset handle state
+    this->m_handle.m_numPriorities = 0;
+    this->m_handle.m_priorityMask.store(1U << Os::VxWorks::Queue::DEFAULT_PRIORITY, std::memory_order_relaxed);
+
+    // Deallocate arrays using stored allocator ID
+    Fw::MemAllocator& allocator = this->getAllocator();
+    this->m_handle.deallocateArrays(allocator, this->m_handle.m_allocatorId);
+
+    // If we were using a configuration, mark it as unused
+    // NOTE: This release operation is not thread-safe by design (teardown is UT-only)
+    FW_ASSERT(s_configs != nullptr || s_configsUsed == nullptr, this->m_handle.m_id);
+    FW_ASSERT(s_configsUsed != nullptr || s_configs == nullptr, this->m_handle.m_id);
+    
+    if (s_configs != nullptr && s_configsUsed != nullptr) {
+        for (FwSizeType i = 0; i < s_numConfigs; ++i) {
+            if (s_configs[i].instanceId == this->m_handle.m_id && s_configsUsed[i].load()) {
+                s_configsUsed[i].store(false);
+                break;
+            }
+        }
+    }
+}
+
+QueueInterface::Status PriorityMemQueue::send(const U8* buffer,
+                                              FwSizeType size,
+                                              FwQueuePriorityType priority,
+                                              QueueInterface::BlockingType blockType) {
+    // Validate input parameters
+    FW_ASSERT(buffer != nullptr, this->m_handle.m_id, priority, blockType);
+    FW_ASSERT(size > 0, this->m_handle.m_id, size, priority);
+
+    // Check if priority is valid
+    if (priority >= Os::VxWorks::Queue::MAX_PRIORITIES) {
+        return QueueInterface::Status::INVALID_PRIORITY;
+    }
+
+    // Check if the queue is initialized
+    if (this->m_handle.m_numPriorities == 0 || this->m_handle.m_msgQueues == nullptr) {
+        return QueueInterface::Status::UNINITIALIZED;
+    }
+
+    // Check if the priority queue exists - no fallback, fail fast
+    MSG_Q_ID msgQ = this->m_handle.m_msgQueues[priority];
+    if (msgQ == nullptr) {
+        if (s_requirePrioritySizing) {
+            FW_ASSERT(0, this->m_handle.m_id, s_requirePrioritySizing, priority);
+        }
+        Fw::Logger::log("ERROR: Priority %d not found for %u, using default priority (%lu)\n", priority,
+                        this->m_handle.m_id, Os::VxWorks::Queue::DEFAULT_PRIORITY);
+        priority = Os::VxWorks::Queue::DEFAULT_PRIORITY;
+        msgQ = this->m_handle.m_msgQueues[priority];
+    }
+    FW_ASSERT(msgQ != nullptr, this->m_handle.m_id, priority, this->m_handle.m_numPriorities);
+
+    // Check for sizing problem
+    if (size > this->m_handle.m_msgSizes[priority]) {
+        return QueueInterface::Status::SIZE_MISMATCH;
+    }
+
+    // Send message using VxWorks msgQSend
+    // msgQSend is ISR-safe and SMP-safe
+    // NOTE: const_cast is required because VxWorks msgQSend API signature uses non-const char*
+    //       even though it does not modify the buffer. This is a legacy C API limitation.
+    int timeout = (blockType == QueueInterface::BlockingType::BLOCKING) ? WAIT_FOREVER : NO_WAIT;
+    STATUS status = msgQSend(msgQ, reinterpret_cast<char*>(const_cast<U8*>(buffer)), 
+                            static_cast<UINT>(size), timeout, MSG_PRI_NORMAL);
+    
+    if (status != OK) {
+        return (errno == S_objLib_OBJ_UNAVAILABLE) ? QueueInterface::Status::FULL : QueueInterface::Status::UNKNOWN_ERROR;
+    }
+
+    // Update per-priority high water mark
+    FW_ASSERT(this->m_handle.m_highWaterMarks != nullptr, this->m_handle.m_id, priority);
+    
+    int numMsgs = msgQNumMsgs(msgQ);
+    U32 currentDepth = static_cast<U32>(numMsgs);
+    U32 prevMax = this->m_handle.m_highWaterMarks[priority].load(std::memory_order_acquire);
+    
+    // Bounded retry loop for CAS operation (max 100 attempts)
+    constexpr U32 MAX_CAS_RETRIES = 100;
+    U32 casRetries = 0;
+    while (currentDepth > prevMax && casRetries < MAX_CAS_RETRIES) {
+        if (this->m_handle.m_highWaterMarks[priority].compare_exchange_weak(prevMax, currentDepth, 
+                                                                            std::memory_order_release,
+                                                                            std::memory_order_acquire)) {
+            break;
+        }
+        ++casRetries;
+    }
+    FW_ASSERT(casRetries < MAX_CAS_RETRIES, this->m_handle.m_id, priority, casRetries);
+    
+    // Post semaphore to wake up receiver (if any)
+    FW_ASSERT(this->m_handle.m_notEmptySem != nullptr, this->m_handle.m_id, priority);
+    STATUS semStatus = semGive(this->m_handle.m_notEmptySem);
+    FW_ASSERT(semStatus == OK, semStatus);
+    
+    return QueueInterface::Status::OP_OK;
+}
+
+QueueInterface::Status PriorityMemQueue::receive(U8* destination,
+                                                 FwSizeType capacity,
+                                                 QueueInterface::BlockingType blockType,
+                                                 FwSizeType& actualSize,
+                                                 FwQueuePriorityType& priority) {
+    // Validate input parameters
+    FW_ASSERT(destination != nullptr, blockType, this->m_handle.m_id);
+
+    // Check if the queue is initialized
+    if (this->m_handle.m_numPriorities == 0 || this->m_handle.m_msgQueues == nullptr) {
+        return QueueInterface::Status::UNINITIALIZED;
+    }
+
+    // Check if the blocking type is valid
+    FW_ASSERT(
+        blockType == QueueInterface::BlockingType::BLOCKING || blockType == QueueInterface::BlockingType::NONBLOCKING,
+        blockType, this->m_handle.m_id);
+
+    // RECEIVE FLOW: Scan all enabled priorities from highest to lowest
+    // Loop:
+    //   1. Get enabled priority mask
+    //   2. Scan from highest to lowest priority
+    //   3. Try msgQReceive NO_WAIT on each enabled priority until message found
+    //   4. If no message: wait on semaphore (blocking) or return empty (non-blocking)
+    //
+    // DESIGN: No state tracking - directly check VxWorks queues.
+    // Semaphore count may desync (multiple receivers wake on single message).
+    // Result: One gets message, others find all queues empty, block again.
+    //
+    // MEMORY ORDERING: Use acquire on priority mask to ensure visibility of queue state.
+    
+    // Bounded loop with compile-time limit for JPL Power of Ten compliance
+    for (U32 reps = 0; reps < LOOP_GUARD_LIMIT; ++reps) {
+        // Get enabled priorities
+        U32 enabledPriorities = this->m_handle.m_priorityMask.load(std::memory_order_acquire);
+        
+        // Scan from highest to lowest priority
+        for (I32 p = Os::VxWorks::Queue::MAX_PRIORITIES - 1; p >= 0; --p) {
+            FwQueuePriorityType testPriority = static_cast<FwQueuePriorityType>(p);
+            
+            // Skip if priority not enabled
+            if ((enabledPriorities & priorityBitMask(testPriority)) == 0) {
+                continue;
+            }
+            
+            FW_ASSERT(this->m_handle.m_msgQueues != nullptr, this->m_handle.m_id, testPriority);
+            MSG_Q_ID msgQ = this->m_handle.m_msgQueues[testPriority];
+            if (msgQ == nullptr) {
+                continue;
+            }
+            
+            // Try to receive with NO_WAIT (non-blocking within this attempt)
+            int bytesRead = msgQReceive(msgQ, reinterpret_cast<char*>(destination), 
+                                      static_cast<UINT>(capacity), NO_WAIT);
+            
+            if (bytesRead > 0) {
+                actualSize = static_cast<FwSizeType>(bytesRead);
+                priority = testPriority;
+                
+                return QueueInterface::Status::OP_OK;
+            }
+        }
+        
+        // No message available
+        if (blockType == QueueInterface::BlockingType::BLOCKING) {
+            // Wait for a message
+            FW_ASSERT(this->m_handle.m_notEmptySem != nullptr, this->m_handle.m_id);
+            STATUS semStatus = semTake(this->m_handle.m_notEmptySem, WAIT_FOREVER);
+            FW_ASSERT(semStatus == OK, semStatus);
+        } else {
+            // Non-blocking, return empty
+            return QueueInterface::Status::EMPTY;
+        }
+    }
+    
+    // Should never reach here - loop guard prevents infinite loop
+    FW_ASSERT(false, this->m_handle.m_id, LOOP_GUARD_LIMIT);
+    return QueueInterface::Status::UNKNOWN_ERROR;
+}
+
+FwSizeType PriorityMemQueue::getMessagesAvailable() const {
+    FwSizeType total = 0;
+
+    if (this->m_handle.m_msgQueues != nullptr) {
+        for (FwSizeType i = 0; i < this->m_handle.m_maxPriorities; ++i) {
+            MSG_Q_ID msgQ = this->m_handle.m_msgQueues[i];
+            if (msgQ != nullptr) {
+                int numMsgs = msgQNumMsgs(msgQ);
+                total += static_cast<FwSizeType>(numMsgs);
+            }
+        }
+    }
+
+    return total;
+}
+
+FwSizeType PriorityMemQueue::getMessageHighWaterMark() const {
+    // Return the maximum high water mark across all priorities
+    // MEMORY ORDERING: Use acquire to ensure visibility of latest HWM updates
+    U32 maxHwm = 0;
+    if (this->m_handle.m_highWaterMarks != nullptr) {
+        for (FwSizeType i = 0; i < this->m_handle.m_maxPriorities; ++i) {
+            U32 hwm = this->m_handle.m_highWaterMarks[i].load(std::memory_order_acquire);
+            if (hwm > maxHwm) {
+                maxHwm = hwm;
+            }
+        }
+    }
+    return static_cast<FwSizeType>(maxHwm);
+}
+
+QueueHandle* PriorityMemQueue::getHandle() {
+    return &this->m_handle;
+}
+
+}  // namespace VxWorks
+}  // namespace Os

--- a/VxWorks/Os/PriorityMemQueue.hpp
+++ b/VxWorks/Os/PriorityMemQueue.hpp
@@ -8,12 +8,12 @@
 // ALL RIGHTS RESERVED.  United States Government Sponsorship
 // acknowledged.
 // ======================================================================
+#include <msgQLib.h>
+#include <semLib.h>
+#include <vxWorks.h>
 #include <atomic>
 #include "Fw/Types/MemAllocator.hpp"
 #include "Os/Queue.hpp"
-#include <vxWorks.h>
-#include <msgQLib.h>
-#include <semLib.h>
 #ifndef OS_VXWORKS_PRIORITYMEMQUEUE_HPP
 #define OS_VXWORKS_PRIORITYMEMQUEUE_HPP
 
@@ -22,7 +22,8 @@ namespace VxWorks {
 
 // Constants
 namespace Queue {
-// JPL heritage implementation supported up to 32 priorities per message queue, limiting to 16 to reduce memory footprint
+// JPL heritage implementation supported up to 32 priorities per message queue, limiting to 16 to reduce memory
+// footprint
 constexpr static FwSizeType MAX_PRIORITIES = 16;
 constexpr static FwSizeType DEFAULT_PRIORITY = 0;
 }  // namespace Queue
@@ -37,20 +38,22 @@ class PriorityMemQueue;
 //! bitmasks and a counting semaphore for receive notification.
 struct PriorityMemQueueHandle : public QueueHandle {
     // Per-priority VxWorks message queues (dynamically allocated)
-    MSG_Q_ID* m_msgQueues;          // Pointer to array of VxWorks message queues
-    FwSizeType* m_msgSizes;         // Pointer to array of max message sizes per priority
-    FwSizeType* m_depths;           // Pointer to array of queue depths per priority
-    FwSizeType m_maxPriorities;     // Size of allocated arrays
-    SEM_ID m_notEmptySem;                  // VxWorks counting semaphore signaling messages available
-    FwEnumStoreType m_id;                  // Queue identifier
-    FwEnumStoreType m_allocatorId;         // Allocator ID for memory operations
-    std::atomic<U32> m_priorityMask;       // Bit mask of enabled priorities
-    std::atomic<U32>* m_highWaterMarks;    // Pointer to array of per-priority high water marks
-    U32 m_numPriorities;                   // Number of priorities
+    MSG_Q_ID* m_msgQueues;               // Pointer to array of VxWorks message queues
+    FwSizeType* m_msgSizes;              // Pointer to array of max message sizes per priority
+    FwQueuePriorityType m_maxPriority;   // Highest priority value (array size = maxPriority + 1)
+    SEM_ID m_notEmptySem;                // VxWorks counting semaphore signaling messages available
+    FwEnumStoreType m_id;                // Queue identifier
+    FwEnumStoreType m_allocatorId;       // Allocator ID for memory operations
+    std::atomic<U32> m_priorityMask;     // Bit mask of enabled priorities
+    std::atomic<U32>* m_highWaterMarks;  // Pointer to array of per-priority high water marks
 
     //! \brief Constructor to initialize semaphore
-    PriorityMemQueueHandle() : m_msgQueues(nullptr), m_msgSizes(nullptr), m_depths(nullptr), 
-                               m_maxPriorities(0), m_notEmptySem(nullptr), m_highWaterMarks(nullptr) {}
+    PriorityMemQueueHandle()
+        : m_msgQueues(nullptr),
+          m_msgSizes(nullptr),
+          m_maxPriority(0),
+          m_notEmptySem(nullptr),
+          m_highWaterMarks(nullptr) {}
 
     //! \brief Initialize the handle
     void init();
@@ -58,8 +61,9 @@ struct PriorityMemQueueHandle : public QueueHandle {
     //! \brief Allocate arrays for priority data
     //! \param allocator: memory allocator to use
     //! \param allocatorId: ID for memory allocation
+    //! \param maxPriority: highest priority value to support (array size will be maxPriority + 1)
     //! \return true if successful, false otherwise
-    bool allocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId);
+    bool allocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId, FwQueuePriorityType maxPriority);
 
     //! \brief Deallocate arrays for priority data
     //! \param allocator: memory allocator to use
@@ -107,7 +111,10 @@ class PriorityMemQueue : public Os::QueueInterface {
     //! \param numQueueConfigs: number of queue configurations
     //! \param required: If true, fatal if a non-default priority is enqueued
     //! \param allocatorId: ID to use for memory allocation
-    static void configure(QueueConfig* queueConfigs, FwSizeType numQueueConfigs, bool required, FwEnumStoreType allocatorId);
+    static void configure(QueueConfig* queueConfigs,
+                          FwSizeType numQueueConfigs,
+                          bool required,
+                          FwEnumStoreType allocatorId);
 
     //! \brief Reset static configuration (test environments only)
     //!
@@ -226,7 +233,7 @@ class PriorityMemQueue : public Os::QueueInterface {
     static bool s_requirePrioritySizing;
     static std::atomic<bool>* s_configsUsed;
     static bool s_configured;
-    
+
   private:
     //! \brief Mark that a priority has messages available
     //! \param priority: priority to mark

--- a/VxWorks/Os/PriorityMemQueue.hpp
+++ b/VxWorks/Os/PriorityMemQueue.hpp
@@ -1,0 +1,307 @@
+// ======================================================================
+// \title  Os/VxWorks/PriorityMemQueue.hpp
+// \author B. Duckett
+// \brief  hpp file for VxWorks msgQ-based priority queue implementation for Os::Queue
+//
+// \copyright
+// Copyright 2026, by the California Institute of Technology.
+// ALL RIGHTS RESERVED.  United States Government Sponsorship
+// acknowledged.
+// ======================================================================
+#include <atomic>
+#include "Fw/Types/MemAllocator.hpp"
+#include "Os/Queue.hpp"
+#include <vxWorks.h>
+#include <msgQLib.h>
+#include <semLib.h>
+#ifndef OS_VXWORKS_PRIORITYMEMQUEUE_HPP
+#define OS_VXWORKS_PRIORITYMEMQUEUE_HPP
+
+namespace Os {
+namespace VxWorks {
+
+// Constants
+namespace Queue {
+// JPL heritage implementation supported up to 32 priorities per message queue, limiting to 16 to reduce memory footprint
+constexpr static FwSizeType MAX_PRIORITIES = 16;
+constexpr static FwSizeType DEFAULT_PRIORITY = 0;
+}  // namespace Queue
+
+// Forward declarations
+class PriorityMemQueue;
+
+//! \brief critical data stored for priority queue
+//!
+//! The priority queue uses VxWorks msgQ API for ISR-safe + SMP-safe operation.
+//! Each priority has its own VxWorks message queue. Priority tracking uses atomic
+//! bitmasks and a counting semaphore for receive notification.
+struct PriorityMemQueueHandle : public QueueHandle {
+    // Per-priority VxWorks message queues (dynamically allocated)
+    MSG_Q_ID* m_msgQueues;          // Pointer to array of VxWorks message queues
+    FwSizeType* m_msgSizes;         // Pointer to array of max message sizes per priority
+    FwSizeType* m_depths;           // Pointer to array of queue depths per priority
+    FwSizeType m_maxPriorities;     // Size of allocated arrays
+    SEM_ID m_notEmptySem;                  // VxWorks counting semaphore signaling messages available
+    FwEnumStoreType m_id;                  // Queue identifier
+    FwEnumStoreType m_allocatorId;         // Allocator ID for memory operations
+    std::atomic<U32> m_priorityMask;       // Bit mask of enabled priorities
+    std::atomic<U32>* m_highWaterMarks;    // Pointer to array of per-priority high water marks
+    U32 m_numPriorities;                   // Number of priorities
+
+    //! \brief Constructor to initialize semaphore
+    PriorityMemQueueHandle() : m_msgQueues(nullptr), m_msgSizes(nullptr), m_depths(nullptr), 
+                               m_maxPriorities(0), m_notEmptySem(nullptr), m_highWaterMarks(nullptr) {}
+
+    //! \brief Initialize the handle
+    void init();
+
+    //! \brief Allocate arrays for priority data
+    //! \param allocator: memory allocator to use
+    //! \param allocatorId: ID for memory allocation
+    //! \return true if successful, false otherwise
+    bool allocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId);
+
+    //! \brief Deallocate arrays for priority data
+    //! \param allocator: memory allocator to use
+    //! \param allocatorId: ID for memory deallocation
+    void deallocateArrays(Fw::MemAllocator& allocator, FwEnumStoreType allocatorId);
+
+    //! \brief Enable a specific priority (in the handle )
+    //!
+    //! \param priority: priority to enable
+    void enablePriority(FwQueuePriorityType priority);
+
+    //! \brief Disable a specific priority
+    //!
+    //! \param priority: priority to disable
+    void disablePriority(FwQueuePriorityType priority);
+};
+//! \brief VxWorks msgQ-based priority queue implementation
+//!
+//! \warning This Priority Queue can be ISR safe
+//!
+//! A VxWorks-specific implementation of a priority queue using msgQ API for ISR-safe + SMP-safe operation.
+//! Each priority has its own VxWorks message queue. Uses counting semaphores for blocking operations.
+//!
+//! \warning allocates memory using MemAllocator
+
+class PriorityMemQueue : public Os::QueueInterface {
+  public:
+    //! \brief Configuration for a priority level
+    struct QueuePriorityConfig {
+        FwQueuePriorityType priority;
+        FwSizeType maxMsgSize;
+        FwSizeType numMsgs;
+    };
+
+    //!\brief Configuration for a queue with multiple priorities
+    struct QueueConfig {
+        FwEnumStoreType instanceId;            // Per component creates pass in instance ID
+        FwSizeType numPriorities;              // Number of priorities
+        QueuePriorityConfig* priorityConfigs;  // Array of priority configurations
+    };
+    //! \brief Register per-priority sizes for component instances which do
+    //! queueing with multiple priorities
+    //! \warning This function must be called before any queues are created
+    //! \param queueConfigs: configuration for the queue
+    //! \param numQueueConfigs: number of queue configurations
+    //! \param required: If true, fatal if a non-default priority is enqueued
+    //! \param allocatorId: ID to use for memory allocation
+    static void configure(QueueConfig* queueConfigs, FwSizeType numQueueConfigs, bool required, FwEnumStoreType allocatorId);
+
+    //! \brief Reset static configuration (test environments only)
+    //!
+    //! Deallocates internal config tracking memory and resets state.
+    //! \warning Only call this in test harnesses after all queues are destroyed
+    static void resetConfig();
+
+  public:
+    //! \brief queue interface constructor - initializes handle
+    PriorityMemQueue();
+
+    //! \brief default queue destructor
+    virtual ~PriorityMemQueue();
+
+    //! \brief copy constructor is forbidden
+    PriorityMemQueue(const QueueInterface& other) = delete;
+
+    //! \brief copy constructor is forbidden
+    PriorityMemQueue(const QueueInterface* other) = delete;
+
+    //! \brief assignment operator is forbidden
+    PriorityMemQueue& operator=(const QueueInterface& other) override = delete;
+
+    //! \brief create queue storage
+    //!
+    //! Creates a queue ensuring sufficient storage to hold `depth` messages of `messageSize` size each.
+    //!
+    //! \warning allocates memory through the memory allocator registry
+    //!
+    //! \param id: identifier for the queue, used for memory allocation
+    //! \param name: name of queue
+    //! \param depth: depth of queue in number of messages
+    //! \param messageSize: size of an individual message
+    //! \return: status of the creation
+    Status create(FwEnumStoreType id,
+                  const Fw::ConstStringBase& name,
+                  FwSizeType depth,
+                  FwSizeType messageSize) override;
+
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
+    //! implementation.
+    void teardown() override;
+
+    //! \brief teardown the queue
+    //!
+    //! Allow for queues to deallocate resources as part of system shutdown. This delegates to the underlying queue
+    //! implementation.
+    //!
+    //! Note: this is a helper to allow this to be called from the destructor.
+    void teardownInternal();
+
+    //! \brief send a message into the queue
+    //!
+    //! Send a message into the queue, providing the message data, size, priority, and blocking type. When
+    //! `blockType` is set to BLOCKING, this call will block on queue full. Otherwise, this will return an error
+    //! status on queue full.
+    //!
+    //! \warning It is invalid to send a null buffer
+    //! \warning This method will block if the queue is full and blockType is set to BLOCKING
+    //! \warning This method is not ISR safe
+    //!
+    //! \param buffer: message data
+    //! \param size: size of message data
+    //! \param priority: priority of the message
+    //! \param blockType: BLOCKING to block for space or NONBLOCKING to return error when queue is full
+    //! \return: status of the send
+    Status send(const U8* buffer, FwSizeType size, FwQueuePriorityType priority, BlockingType blockType) override;
+
+    //! \brief receive a message from the queue
+    //!
+    //! Receive a message from the queue, providing the message destination, capacity, priority, and blocking type.
+    //! When `blockType` is set to BLOCKING, this call will block on queue empty. Otherwise, this will return an
+    //! error status on queue empty. Actual size received and priority of message is set on success status.
+    //!
+    //! \warning It is invalid to send a null buffer
+    //! \warning This method will block if the queue is empty and blockType is set to BLOCKING
+    //! \warning This method is not ISR safe
+    //!
+    //! \param destination: destination for message data
+    //! \param capacity: maximum size of message data
+    //! \param blockType: BLOCKING to wait for message or NONBLOCKING to return error when queue is empty
+    //! \param actualSize: (output) actual size of message read
+    //! \param priority: (output) priority of message read
+    //! \return: status of the send
+    Status receive(U8* destination,
+                   FwSizeType capacity,
+                   BlockingType blockType,
+                   FwSizeType& actualSize,
+                   FwQueuePriorityType& priority) override;
+
+    //! \brief get number of messages available
+    //!
+    //! \return number of messages available
+    FwSizeType getMessagesAvailable() const override;
+
+    //! \brief get maximum messages stored at any given time
+    //!
+    //! \warning This method is not ISR safe
+    //!
+    //! Returns the maximum number of messages in this queue at any given time. This is the high-water mark for this
+    //! queue.
+    //! \return queue message high-water mark
+    FwSizeType getMessageHighWaterMark() const override;
+
+    QueueHandle* getHandle() override;
+
+    PriorityMemQueueHandle m_handle;
+
+  private:
+    //! \brief Static configuration storage
+    //! \warning must be initialized by config
+    static QueueConfig* s_configs;
+    static FwSizeType s_numConfigs;
+    static bool s_requirePrioritySizing;
+    static std::atomic<bool>* s_configsUsed;
+    static bool s_configured;
+    
+  private:
+    //! \brief Mark that a priority has messages available
+    //! \param priority: priority to mark
+    void markPriorityHasMessages(FwQueuePriorityType priority);
+
+    //! \brief Clear the flag indicating a priority has messages
+    //! \param priority: priority to clear
+    void clearPriorityHasMessages(FwQueuePriorityType priority);
+
+    //! \brief Get mask of enabled priorities that have messages
+    //! \return bit mask of priorities that are both enabled and have messages
+    U32 getEnabledPrioritiesWithMessages() const;
+
+    //! \brief Find the highest priority with available messages
+    //! \return highest priority with available messages, or MAX_PRIORITIES if none
+    FwQueuePriorityType findHighestPriority(U32 priorities = 0);
+
+    //! \brief Check if a priority is enabled
+    //! \param priority: priority to check
+    //! \return true if the priority is enabled, false otherwise
+    bool isPriorityEnabled(FwQueuePriorityType priority);
+
+    //! \brief Enable or disable a priority (internal)
+    //! \param priority: priority to enable or disable
+    //! \param enabled: true to enable, false to disable
+    void setPriorityEnabled(FwQueuePriorityType priority, bool enabled);
+
+    //! \brief Get the memory allocator for this queue (Fix #7: Memory Allocation Coordination)
+    //! \return reference to the memory allocator
+    Fw::MemAllocator& getAllocator();
+
+  private:
+    //! \brief Find a matching configuration for the given ID
+    //!
+    //! \param id: identifier for the queue
+    //! \return: pointer to the matching configuration, or nullptr if none found
+    QueueConfig* findMatchingConfig(FwEnumStoreType id);
+
+    //! \brief Create queues based on configuration
+    //!
+    //! \param queueConfig: configuration for the queue
+    //! \param allocator: memory allocator to use
+    //! \param allocatorId: ID to use for memory allocation
+    //! \return: status of the creation
+    QueueInterface::Status createConfiguredQueues(QueueConfig* queueConfig,
+                                                  Fw::MemAllocator& allocator,
+                                                  FwEnumStoreType allocatorId);
+
+    //! \brief Create a single default priority queue
+    //!
+    //! \param depth: depth of queue in number of messages
+    //! \param messageSize: size of an individual message
+    //! \param allocator: memory allocator to use
+    //! \param allocatorId: ID to use for memory allocation
+    //! \return: status of the creation
+    QueueInterface::Status createDefaultQueue(FwSizeType depth,
+                                              FwSizeType messageSize,
+                                              Fw::MemAllocator& allocator,
+                                              FwEnumStoreType allocatorId);
+
+    //! \brief Create a single priority queue
+    //!
+    //! \param priority: priority of the queue
+    //! \param maxMsgSize: maximum size of a message
+    //! \param numMsgs: number of messages to allocate space for
+    //! \param allocator: memory allocator to use
+    //! \param allocatorId: ID to use for memory allocation
+    //! \return: status of the creation
+    QueueInterface::Status createPriorityQueue(FwQueuePriorityType priority,
+                                               FwSizeType maxMsgSize,
+                                               FwSizeType numMsgs,
+                                               Fw::MemAllocator& allocator,
+                                               FwEnumStoreType allocatorId);
+};
+}  // namespace VxWorks
+}  // namespace Os
+
+#endif  // OS_VXWORKS_PRIORITYMEMQUEUE_HPP

--- a/VxWorks/Os/docs/sdd.md
+++ b/VxWorks/Os/docs/sdd.md
@@ -1,0 +1,152 @@
+# VxWorks PriorityMemQueue Implementation
+
+## Os::PriorityMemQueue
+
+Os::PriorityMemQueue is an ISR-safe and SMP-safe, priority-based memory queue implementation for F´ using VxWorks message queues (msgQ). This implementation leverages the VxWorks msgQ API to provide robust multi-core synchronization without the need for a critical section lock, reducing complexity (at the cost of portability).
+
+The key components are:
+
+1. **VxWorks msgQ** - One msgQ per priority level for ISR-safe + SMP-safe message storage
+2. **Atomic Priority Tracking** - Lock-free bitmasks to track which priorities have messages
+3. **Counting Semaphore** - Notification mechanism for blocking receive operations
+4. **PriorityMemQueue** - Main queue implementation that implements Os::QueueInterface
+
+### Requirements
+
+The requirements for `Os::Generic::PriorityMemQueue` are as follows:
+
+Requirement | Description | Verification Method
+----------- | ----------- | -------------------
+PMQ-001 | The PriorityMemQueue shall implement the Os::QueueInterface for compatibility with F´ components | Inspection, Unit Test
+PMQ-002 | The PriorityMemQueue shall support up to 16 priority levels | Inspection, Unit Test
+PMQ-003 | The PriorityMemQueue shall allocate separate memory pools for each priority level | Inspection, Unit Test
+PMQ-004 | The PriorityMemQueue shall support per-priority configuration of message size and depth | Inspection, Unit Test
+PMQ-005 | The PriorityMemQueue shall support blocking and non-blocking send operations | Unit Test
+PMQ-006 | The PriorityMemQueue shall support blocking and non-blocking receive operations | Unit Test
+PMQ-007 | The PriorityMemQueue shall dequeue messages in priority order, with the highest enabled priority serviced first | Unit Test
+PMQ-008 | The PriorityMemQueue shall support dynamic enable/disable of individual priority levels | Unit Test
+PMQ-009 | The PriorityMemQueue shall be configurable to be ISR-safe for message enqueue and dequeue operations | Platform dependent
+PMQ-010 | The PriorityMemQueue shall track high water marks for message queue depth | Unit Test
+PMQ-011 | The PriorityMemQueue shall validate message sizes against priority-specific limits | Unit Test
+PMQ-012 | The PriorityMemQueue shall use the F´ memory allocator registry for all dynamic allocations | Inspection
+PMQ-013 | The PriorityMemQueue shall return appropriate error codes for queue full, empty, and invalid priority conditions | Unit Test
+PMQ-014 | The PriorityMemQueue shall provide per-priority O(1) enqueue and dequeue operations | Inspection
+
+> [!WARNING]
+> Send/receive operations from ISR context must not use blocking behavior 
+
+> [!NOTE]
+> Os::PriorityMemQueue provides ISR safety and per-priority configuration at the cost of increased complexity and memory usage compared to Os::PriorityQueue.
+
+### VxWorks msgQ-Based Architecture
+
+#### Overview
+
+`PriorityMemQueue` uses VxWorks message queues (`msgQLib`) for message storage and synchronization. This approach leverages Wind River's platform-optimized queue implementation that provides:
+- **ISR Safety**: `msgQSend` can be called from interrupt context
+- **SMP Safety**: Atomic operations prevent multi-core race conditions
+- **No Interrupt Starvation**: msgQ uses task-level synchronization internally, not global interrupt disable
+- **Platform Optimization**: Wind River has tuned msgQ performance for VxWorks SMP systems
+
+#### Per-Priority Message Queues
+
+Each priority level has its own dedicated VxWorks message queue created with `msgQCreate()`:
+
+```cpp
+MSG_Q_ID msgQ = msgQCreate(numMsgs, maxMsgSize, MSG_Q_FIFO);
+```
+
+**Parameters**:
+- `numMsgs`: Maximum number of messages for this priority
+- `maxMsgSize`: Maximum message size in bytes
+- `MSG_Q_FIFO`: FIFO ordering within the priority level
+
+**Storage** (Dynamically Allocated):
+
+PriorityMemQueue dynamically allocates arrays for tracking per-queue max msg size, number of message buffers, and msgQ state. 
+
+#### Priority Tracking with Atomics
+
+To implement priority-based dequeue ordering, `PriorityMemQueue` maintains lock-free atomic bitmasks:
+
+```cpp
+std::atomic<U32> m_priorityMask;       // Which priorities are enabled (bit per priority)
+std::atomic<U32> m_prioritiesWithMsg;  // Which priorities have messages
+```
+
+**Send Flow**:
+1. Call `msgQSend()` - VxWorks handles synchronization
+2. Atomically set bit: `m_prioritiesWithMsg.fetch_or(1 << priority)`
+3. Post semaphore to wake receiver: `m_notEmpty.post()`
+
+**Receive Flow**:
+1. Read bitmask (lock-free): `priorities = m_prioritiesWithMsg & m_priorityMask`
+2. Find highest priority bit set
+3. Call `msgQReceive(msgQ[priority], ..., NO_WAIT)`
+4. If queue was empty, block on semaphore: `m_notEmpty.wait()`
+5. If queue now empty, atomically clear bit: `m_prioritiesWithMsg.fetch_and(~(1 << priority))`
+6. Return dequeued message
+
+This design minimizes synchronization overhead - only atomic operations on small integers, no spinlocks needed.
+
+### PriorityMemQueue Overview
+
+`PriorityMemQueue` is the main class that implements `Os::QueueInterface`. It provides a multi-priority message queue with configurable ISR-safe operations and flexible per-priority configuration.
+
+**Priority Ordering**: Larger priority numbers have higher priority than lower priority numbers (i.e., priority 0 is the lowest priority, priority 15 is the highest).
+
+**Key Features**:
+- **Multi-Priority Support**: Up to 16 independent priority levels (0-15)
+- **Per-Priority Memory Pools**: Each priority has dedicated buffer allocation 
+- **ISR-Safe Operations**: Non-blocking send/receive can be called from interrupt context (platform-dependent)
+- **Flexible Configuration**: Static configuration allows per-component, per-priority sizing
+- **Priority Management**: Runtime enable/disable of individual priority levels
+- **Blocking Support**: Optional blocking behavior for send and receive operations using counting semaphores
+- **High Water Mark Tracking**: Monitors peak queue usage for system analysis
+- **Dynamic Memory Allocation**: Arrays allocated only when needed, reducing memory footprint
+
+#### Synchronization
+
+**PriorityMemQueue** uses a counting semaphore for blocking receive operations:
+- **m_notEmpty**: Semaphore count represents number of messages available across all priorities
+  - Initialized to 0 (queue starts empty)
+  - `post()` called after successful enqueue to signal message availability
+  - `wait()` blocks receiver when count reaches 0 (queue empty)
+  - After `wait()` returns, receiver dequeues from highest priority with messages
+
+A semaphore is used (as opposed to a condition variable & mutex) because:
+- Semaphores are ISR safe 
+- Simplifies synchronization 
+    - No need for separate mutex acquisition before checking queue state
+    - No double-check pattern required to prevent lost notifications
+    - Semaphore count intrinsically tracks message availability
+
+### Configuration 
+
+The static configuration system allows per-component, per-priority queue sizing. This enables fine-grained memory allocation tailored to each component's messaging patterns.
+
+If a configuration is not provided for a given queue instance ID, then create() will use the message max size and depth arguments for priority DEFAULT_PRIORITY (0). 
+
+### ISR Safety
+
+The VxWorks msgQ-based implementation provides ISR safety through:
+
+1. **msgQSend()**: ISR-safe by design in VxWorks
+   - Can be called with `NO_WAIT` timeout from interrupt context
+   - Uses atomic operations internally for SMP safety
+   
+2. **Atomic Bitmasks**: Lock-free priority tracking
+   - `std::atomic<U32>` operations are compiler-intrinsic atomics
+   - No interrupt disable or mutex needed
+   
+3. **msgQReceive()**: ISR-safe with `NO_WAIT` timeout
+   - Non-blocking variant safe from interrupt context
+
+**ISR Usage Pattern**:
+```cpp
+// From ISR context - use NONBLOCKING
+queue.send(data, size, priority, QueueInterface::BlockingType::NONBLOCKING);
+queue.receive(dest, capacity, QueueInterface::BlockingType::NONBLOCKING, size, pri);
+```
+
+


### PR DESCRIPTION
PriorityMemQueue is an Os::Queue implementation with per priority message sizing, it's ISR & SMP multi-core safe. 
It doesn't include unit tests yet because it relies on OS specific interfaces (so can't compile for linux) 

AI Usage
Claude Sonnet was used in code review & refactoring. All code has been reviewed by a human and confirmed to run correctly in an VxWorks deployment