### PR TITLE
Undefed bool_t because it collides with non-vxworks code

### DIFF
--- a/cmake/platform/types/Platform/PlatformTypes.h
+++ b/cmake/platform/types/Platform/PlatformTypes.h
@@ -20,8 +20,6 @@ extern "C" {
 
 // collides with a boolean type elsewhere
 #undef boolean_t
-#undef TRUE
-#undef FALSE
 
 // Capture current value of VxWorks constants
 enum VxWorksConstants {
@@ -29,7 +27,9 @@ enum VxWorksConstants {
 	VXWORKS_READ = READ,
 	VXWORKS_OK = OK,
 	VXWORKS_NO_WAIT = NO_WAIT,
-	VXWORKS_NONE = NONE
+	VXWORKS_NONE = NONE,
+	VXWORKS_TRUE = TRUE,
+	VXWORKS_FALSE = FALSE
 };
 
 #undef OK
@@ -37,6 +37,8 @@ enum VxWorksConstants {
 #undef READ
 #undef NO_WAIT
 #undef NONE
+#undef TRUE
+#undef FALSE
 
 // Redefine constants as enumeration
 enum {
@@ -44,7 +46,9 @@ enum {
 	READ = VXWORKS_READ,
 	OK = VXWORKS_OK,
 	NO_WAIT = VXWORKS_NO_WAIT,
-	NONE = VXWORKS_NONE
+	NONE = VXWORKS_NONE,
+    TRUE =  VXWORKS_TRUE,
+    FALSE = VXWORKS_FALSE
 };
 
 #include <inttypes.h>

--- a/cmake/platform/types/Platform/PlatformTypes.h
+++ b/cmake/platform/types/Platform/PlatformTypes.h
@@ -18,6 +18,11 @@ extern "C" {
 
 #include <vxWorks.h>
 
+// collides with a boolean type elsewhere
+#undef boolean_t
+#undef TRUE
+#undef FALSE
+
 // Capture current value of VxWorks constants
 enum VxWorksConstants {
 	VXWORKS_ERROR = ERROR,


### PR DESCRIPTION
The `bool_t` type collides with other 3rd party code that defines it. Since F Prime doesn't need the type, undef it after the VxWorks include.